### PR TITLE
uci: decrease the n_section when section is freed

### DIFF
--- a/list.c
+++ b/list.c
@@ -228,6 +228,7 @@ uci_free_section(struct uci_section *s)
 	if ((s->type != uci_dataptr(s)) &&
 		(s->type != NULL))
 		free(s->type);
+	s->package->n_section--;
 	uci_free_element(&s->e);
 }
 
@@ -734,7 +735,6 @@ int uci_set(struct uci_context *ctx, struct uci_ptr *ptr)
 			if (ptr->section == old->e.name)
 				ptr->section = ptr->s->e.name;
 			uci_free_section(old);
-			ptr->s->package->n_section--;
 		}
 	} else {
 		UCI_THROW(ctx, UCI_ERR_INVAL);


### PR DESCRIPTION
Recently, I'm working on an application compiled with libuci, and it will keep the content of the package.

However, I have found that sometimes an anonymous section still remains in the config after calling the uci_delete.

It was discovered that the issue was caused by using the wrong section name.

The package n_section counter increases when a section is allocated but does not decrease when a section is freed.

Since the anonymous section name is comprised of the section counter, if the package is not reloaded, an incorrect count will result in operating on the wrong section.

