### PR TITLE
In batch mode, print empty line if get fails

### DIFF
--- a/cli.c
+++ b/cli.c
@@ -476,6 +476,9 @@ static int uci_do_section_cmd(int cmd, int argc, char **argv)
 		return 255;
 
 	if (uci_lookup_ptr(ctx, &ptr, argv[1], true) != UCI_OK) {
+		if (flags & CLI_FLAG_BATCH && cmd == CMD_GET)
+			printf("\n");
+
 		cli_perror();
 		return 1;
 	}
@@ -488,6 +491,9 @@ static int uci_do_section_cmd(int cmd, int argc, char **argv)
 	switch(cmd) {
 	case CMD_GET:
 		if (!(ptr.flags & UCI_LOOKUP_COMPLETE)) {
+			if (flags & CLI_FLAG_BATCH)
+				printf("\n");
+
 			ctx->err = UCI_ERR_NOTFOUND;
 			cli_perror();
 			return 1;

--- a/libuci.c
+++ b/libuci.c
@@ -160,6 +160,8 @@ uci_get_errorstr(struct uci_context *ctx, char **dest, const char *prefix)
 	static char error_info[128] = { 0 };
 	int err;
 
+	error_info[0] = '\0';
+
 	err = ctx ? ctx->err : UCI_ERR_INVAL;
 	if ((err < 0) || (err >= UCI_ERR_LAST))
 		err = UCI_ERR_UNKNOWN;


### PR DESCRIPTION
Currently get commands return nothing to stdout on error in batch mode. In practice, this makes them hard to use in scripts. If the caller sends 4 gets and we only return 3 lines, the caller can not easily determine which one did not work.

This changes the get command behavior in batch mode to always print a new line, even on error. This allows the caller to determine which get did not work. e.x. if the 3rd line is blank then the 3rd get did not work.

Also fixes #3 

CC: @cmonroe 