### PR TITLE
uci: fix cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
-INCLUDE(GNUInstallDirs)
 
 PROJECT(uci C)
+INCLUDE(GNUInstallDirs)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-
 PROJECT(uci C)
 
 SET(CMAKE_INSTALL_PREFIX /)


### PR DESCRIPTION
First, remove minimum cmake version for subdirs.

Second, reorder the main CMakeLists.txt file to fix this warning:

CMake Warning (dev) at /usr/share/cmake-3.31/Modules/GNUInstallDirs.cmake:253 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.