### PR TITLE
build: install uci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
           mkdir -p ${GITHUB_WORKSPACE}/build
           mkdir -p ${GITHUB_WORKSPACE}/depends/lua
           echo "${GITHUB_WORKSPACE}/build/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/lib:${{ env.LD_LIBRARY_PATH }}" >> $GITHUB_ENV
 
       - name: Build json-c
         working-directory: depends/json-c
@@ -237,8 +238,10 @@ jobs:
             -DBUILD_LUA=ON \
             -DUNIT_TESTING=ON \
             -DLUAPATH=${GITHUB_WORKSPACE}/build/lib/lua \
+            --install-prefix ${GITHUB_WORKSPACE}/build \
             -B . -S .
           make
+          make install
 
       - name: Test uci
         run: |

--- a/scripts/devel-build.sh
+++ b/scripts/devel-build.sh
@@ -23,6 +23,10 @@ DEPSDIR="${BUILDDIR}/depends"
 [ -e "${BUILDDIR}" ] || mkdir "${BUILDDIR}"
 [ -e "${DEPSDIR}" ] || mkdir "${DEPSDIR}"
 
+# Prepare env
+export LD_LIBRARY_PATH="${BUILDDIR}/lib:${LD_LIBRARY_PATH:-}"
+export PATH="${BUILDDIR}/bin:${PATH:-}"
+
 # Download deps
 cd "${DEPSDIR}"
 [ -e "json-c" ] || git clone https://github.com/json-c/json-c.git
@@ -73,11 +77,16 @@ cmake							\
 	-B "${BUILDDIR}"				\
 	-DCMAKE_PREFIX_PATH="${BUILDDIR}"		\
 	-DLUAPATH=${BUILDDIR}/lib/lua			\
+	--install-prefix "${BUILDDIR}"			\
 	${BUILD_ARGS}
-make -C "${BUILDDIR}" all test CTEST_OUTPUT_ON_FAILURE=1
+make -C "${BUILDDIR}"
+make -C "${BUILDDIR}" install
+
+# Test uci
+make -C "${BUILDDIR}" test CTEST_OUTPUT_ON_FAILURE=1
 
 set +x
-echo "✅ Success - the uci library is available at ${BUILDDIR}"
+echo "✅ Success - uci is available at ${BUILDDIR}"
 echo "👷 You can rebuild uci by running 'make -C build'"
 
 exit 0


### PR DESCRIPTION
Install uci and properly use it by adding it to PATH and LD_LIBRARY_PATH. This is needed in order to use a proper environment for testing.