### PR TITLE
github: ci: add MIPS64, PowerPC64 and RISCV64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
 
 env:
+  archs: "aarch64 arm mips mips64 powerpc powerpc64 riscv64 x86_64"
+  variants: "basic full"
   LUA_VERSION: 5.1.5
 
 jobs:
@@ -24,9 +26,18 @@ jobs:
           - arch: mips
             gcc: /usr/bin/mips-linux-gnu-gcc
             packages: gcc-mips-linux-gnu
+          - arch: mips64
+            gcc: /usr/bin/mips64-linux-gnuabi64-gcc
+            packages: gcc-mips64-linux-gnuabi64
           - arch: powerpc
             gcc: /usr/bin/powerpc-linux-gnu-gcc
             packages: gcc-powerpc-linux-gnu
+          - arch: powerpc64
+            gcc: /usr/bin/powerpc64-linux-gnu-gcc
+            packages: gcc-powerpc64-linux-gnu
+          - arch: riscv64
+            gcc: /usr/bin/riscv64-linux-gnu-gcc
+            packages: gcc-riscv64-linux-gnu
           - arch: x86_64
             gcc: /usr/bin/x86_64-linux-gnu-gcc
             packages: gcc-x86-64-linux-gnu
@@ -37,8 +48,14 @@ jobs:
       size-arm-full: ${{ steps.full.outputs.size_arm }}
       size-mips-basic: ${{ steps.basic.outputs.size_mips }}
       size-mips-full: ${{ steps.full.outputs.size_mips }}
+      size-mips64-basic: ${{ steps.basic.outputs.size_mips64 }}
+      size-mips64-full: ${{ steps.full.outputs.size_mips64 }}
       size-powerpc-basic: ${{ steps.basic.outputs.size_powerpc }}
       size-powerpc-full: ${{ steps.full.outputs.size_powerpc }}
+      size-powerpc64-basic: ${{ steps.basic.outputs.size_powerpc64 }}
+      size-powerpc64-full: ${{ steps.full.outputs.size_powerpc64 }}
+      size-riscv64-basic: ${{ steps.basic.outputs.size_riscv64 }}
+      size-riscv64-full: ${{ steps.full.outputs.size_riscv64 }}
       size-x86_64-basic: ${{ steps.basic.outputs.size_x86_64 }}
       size-x86_64-full: ${{ steps.full.outputs.size_x86_64 }}
     steps:
@@ -153,16 +170,36 @@ jobs:
           size_arm_full: ${{needs.build.outputs.size-arm-full}}
           size_mips_basic: ${{needs.build.outputs.size-mips-basic}}
           size_mips_full: ${{needs.build.outputs.size-mips-full}}
+          size_mips64_basic: ${{needs.build.outputs.size-mips64-basic}}
+          size_mips64_full: ${{needs.build.outputs.size-mips64-full}}
           size_powerpc_basic: ${{needs.build.outputs.size-powerpc-basic}}
           size_powerpc_full: ${{needs.build.outputs.size-powerpc-full}}
+          size_powerpc64_basic: ${{needs.build.outputs.size-powerpc64-basic}}
+          size_powerpc64_full: ${{needs.build.outputs.size-powerpc64-full}}
+          size_riscv64_basic: ${{needs.build.outputs.size-riscv64-basic}}
+          size_riscv64_full: ${{needs.build.outputs.size-riscv64-full}}
           size_x86_64_basic: ${{needs.build.outputs.size-x86_64-basic}}
           size_x86_64_full: ${{needs.build.outputs.size-x86_64-full}}
         run: |
           echo "### ${GITHUB_WORKFLOW} sizes :floppy_disk:" >> $GITHUB_STEP_SUMMARY
-          echo "| Variant | aarch64 | arm | mips | powerpc | x86_64 |" >> $GITHUB_STEP_SUMMARY
-          echo "| :---: | :---: | :---: | :---: | :---: | :---: |" >> $GITHUB_STEP_SUMMARY
-          echo "| basic | ${size_aarch64_basic} | ${size_arm_basic} | ${size_mips_basic} | ${size_powerpc_basic} | ${size_x86_64_basic} |" >> $GITHUB_STEP_SUMMARY
-          echo "| full | ${size_aarch64_full} | ${size_arm_full} | ${size_mips_full} | ${size_powerpc_full} | ${size_x86_64_full} |" >> $GITHUB_STEP_SUMMARY
+
+          header="| arch |"
+          table="| :---: |"
+          for variant in ${{ env.variants }}; do
+            header="$header $variant |"
+            table="$table :---: |"
+          done
+          echo $header >> $GITHUB_STEP_SUMMARY
+          echo $table >> $GITHUB_STEP_SUMMARY
+
+          for arch in ${{ env.archs }}; do
+            row="| $arch | "
+            for variant in $variants; do
+              value=size_${arch}_$(echo "$variant" | tr "[:upper:]" "[:lower:]")
+              row="$row ${!value} |"
+            done
+            echo $row >> $GITHUB_STEP_SUMMARY
+          done
 
   tests:
     name: Tests


### PR DESCRIPTION
MIPS64, PowerPC64 and RISCV64 are popular OpenWrt archs.
Refactor the sizes build step to generate the table programatically.