### PR TITLE
add preservation of comment lines

### DIFF
--- a/cli.c
+++ b/cli.c
@@ -148,11 +148,11 @@ static void uci_usage(void)
 		"\tchanges    [<config>]\n"
 		"\tcommit     [<config>]\n"
 		"\tadd        <config> <section-type>\n"
-		"\tadd_list   <config>.<section>.<option>=<string>\n"
+		"\tadd_list   <config>.<section>.<option>=<string> [<comment>]\n"
 		"\tdel_list   <config>.<section>.<option>=<string>\n"
 		"\tshow       [<config>[.<section>[.<option>]]]\n"
-		"\tget        <config>.<section>[.<option>]\n"
-		"\tset        <config>.<section>[.<option>]=<value>\n"
+		"\tget        <config>.<section>[.<option>] [#]\n"
+		"\tset        <config>.<section>[.<option>]=<value> [<comment>]\n"
 		"\tdelete     <config>[.<section>[[.<option>][=<id>]]]\n"
 		"\trename     <config>.<section>[.<option>]=<name>\n"
 		"\trevert     <config>[.<section>[.<option>]]\n"
@@ -162,6 +162,7 @@ static void uci_usage(void)
 		"\t-c <path>  set the search path for config files (default: "UCI_CONFDIR")\n"
 		"\t-C <path>  set the search path for config override files (default: "UCI_CONF2DIR")\n"
 		"\t-d <str>   set the delimiter for list values in uci show\n"
+		"\t-D         don't load, store in memory, or save comments\n"
 		"\t-f <file>  use <file> as input instead of stdin\n"
 		"\t-m         when importing, merge data into an existing package\n"
 		"\t-n         name unnamed sections on export (default)\n"
@@ -212,7 +213,42 @@ static void uci_print_value(FILE *f, const char *v)
 	fprintf(f, "'");
 }
 
-static void uci_show_value(struct uci_option *o, bool quote)
+static void uci_print_changes_comment(FILE *f, const char *comment)
+{
+	if (!comment || !comment[0])
+		return;
+
+	fputc('#', f);
+	for (const char *readptr = comment; *readptr; readptr++) {
+		if (*readptr == '\\') {
+			fputc('\\', f);
+			fputc('\\', f);
+		} else if (*readptr == '\n') {
+			fputc('\\', f);
+			fputc('n', f);
+		} else
+			fputc(*readptr, f);
+	}
+}
+
+static void uci_print_comment(FILE *f, const char *comment)
+{
+	fputc('\'', f);
+	if (comment) {
+		for (const char *readptr = comment; *readptr; readptr++) {
+			if (*readptr != '\'')
+				fputc(*readptr, f);
+			else {
+				fputc('\'', f); /* end single-quoted string */
+				fputc('\\', f); fputc('\'', f); /* escaped single quote */
+				fputc('\'', f); /* start single-quoted string */
+			}
+		}
+	}
+	fputc('\'', f);
+}
+
+static void uci_show_option_value(struct uci_option *o, bool quote)
 {
 	struct uci_element *e;
 	bool sep = false;
@@ -224,7 +260,6 @@ static void uci_show_value(struct uci_option *o, bool quote)
 			uci_print_value(stdout, o->v.string);
 		else
 			printf("%s", o->v.string);
-		printf("\n");
 		break;
 	case UCI_TYPE_LIST:
 		uci_foreach_element(&o->v.list, e) {
@@ -236,10 +271,31 @@ static void uci_show_value(struct uci_option *o, bool quote)
 				uci_print_value(stdout, e->name);
 			sep = true;
 		}
-		printf("\n");
 		break;
 	default:
-		printf("<unknown>\n");
+		printf("<unknown>");
+		break;
+	}
+}
+
+static void uci_show_option_comment(struct uci_option *o)
+{
+	struct uci_element *e;
+	bool sep = false;
+
+	switch(o->type) {
+	case UCI_TYPE_STRING:
+		uci_print_comment(stdout, o->e.comment);
+		break;
+	case UCI_TYPE_LIST:
+		uci_foreach_element(&o->v.list, e) {
+			printf("%s", (sep ? delimiter : ""));
+			uci_print_comment(stdout, e->comment);
+			sep = true;
+		}
+		break;
+	default:
+		printf("<unknown>");
 		break;
 	}
 }
@@ -250,7 +306,8 @@ static void uci_show_option(struct uci_option *o, bool quote)
 		o->section->package->e.name,
 		(cur_section_ref ? cur_section_ref : o->section->e.name),
 		o->e.name);
-	uci_show_value(o, quote);
+	uci_show_option_value(o, quote);
+	printf("\n");
 }
 
 static void uci_show_section(struct uci_section *s)
@@ -261,7 +318,8 @@ static void uci_show_section(struct uci_section *s)
 
 	cname = s->package->e.name;
 	sname = (cur_section_ref ? cur_section_ref : s->e.name);
-	printf("%s.%s=%s\n", cname, sname, s->type);
+	printf("%s.%s=%s", cname, sname, s->type);
+	printf("\n");
 	uci_foreach_element(&s->options, e) {
 		uci_show_option(uci_to_option(e), true);
 	}
@@ -309,6 +367,8 @@ static void uci_show_changes(struct uci_package *p)
 			printf("%s", op);
 			uci_print_value(stdout, h->value);
 		}
+		if (!(ctx->flags & UCI_FLAG_NO_COMMENTS))
+			uci_print_changes_comment(stdout, e->comment);
 		printf("\n");
 	}
 }
@@ -472,7 +532,8 @@ static int uci_do_section_cmd(int cmd, int argc, char **argv)
 	int ret = UCI_OK;
 	int dummy;
 
-	if (argc != 2)
+	if (!((argc == 2) ||
+	      ((argc == 3) && ((cmd == CMD_GET) || (cmd == CMD_SET) || (cmd == CMD_ADD_LIST)))))
 		return 255;
 
 	if (uci_lookup_ptr(ctx, &ptr, argv[1], true) != UCI_OK) {
@@ -483,10 +544,19 @@ static int uci_do_section_cmd(int cmd, int argc, char **argv)
 		return 1;
 	}
 
+	if (argc == 3) {
+		ptr.comment = argv[2];
+		if ((cmd == CMD_GET) && strcmp(ptr.comment, "#"))
+			return 1;
+		else if (!uci_validate_comment(ptr.comment))
+			return 1;
+	}
+
 	if (ptr.value && (cmd != CMD_SET) && (cmd != CMD_DEL) &&
 	    (cmd != CMD_ADD_LIST) && (cmd != CMD_DEL_LIST) &&
 	    (cmd != CMD_RENAME) && (cmd != CMD_REORDER))
 		return 1;
+
 
 	switch(cmd) {
 	case CMD_GET:
@@ -498,10 +568,20 @@ static int uci_do_section_cmd(int cmd, int argc, char **argv)
 			cli_perror();
 			return 1;
 		}
-		if (ptr.o)
-			uci_show_value(ptr.o, false);
-		else if (ptr.s)
-			printf("%s\n", ptr.s->type);
+		if (ptr.o) {
+			if (!ptr.comment)
+				uci_show_option_value(ptr.o, false);
+			else
+				uci_show_option_comment(ptr.o);
+			printf("\n");
+		}
+		else if (ptr.s) {
+			if (!ptr.comment)
+				printf("%s", ptr.s->type);
+			else
+				uci_print_comment(stdout, ptr.s->e.comment);
+			printf("\n");
+		}
 		break;
 	case CMD_RENAME:
 		ret = uci_rename(ctx, &ptr);
@@ -685,7 +765,7 @@ static int uci_cmd(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-	int ret;
+	int ret = 1;
 	int c;
 
 	flags = CLI_FLAG_SHOW_EXT;
@@ -694,10 +774,10 @@ int main(int argc, char **argv)
 	ctx = uci_alloc_context();
 	if (!ctx) {
 		cli_error("Out of memory\n");
-		return 1;
+		goto cleanup;
 	}
 
-	while((c = getopt(argc, argv, "c:C:d:f:LmnNp:P:qsSt:X")) != -1) {
+	while((c = getopt(argc, argv, "c:C:d:Df:LmnNp:P:qsSt:X")) != -1) {
 		switch(c) {
 			case 'c':
 				uci_set_confdir(ctx, optarg);
@@ -712,14 +792,17 @@ int main(int argc, char **argv)
 				if (input != stdin) {
 					fclose(input);
 					cli_error("Too many input files.\n");
-					return 1;
+					goto cleanup;
 				}
 
 				input = fopen(optarg, "r");
 				if (!input) {
 					cli_error("uci: %s", strerror(errno));
-					return 1;
+					goto cleanup;
 				}
+				break;
+			case 'D':
+				ctx->flags |= UCI_FLAG_NO_COMMENTS;
 				break;
 			case 'm':
 				flags |= CLI_FLAG_MERGE;
@@ -755,7 +838,8 @@ int main(int argc, char **argv)
 				break;
 			default:
 				uci_usage();
-				return 0;
+				ret = 0;
+				goto cleanup;
 		}
 	}
 	if (optind > 1)
@@ -765,7 +849,8 @@ int main(int argc, char **argv)
 
 	if (argc < 2) {
 		uci_usage();
-		return 0;
+		ret = 0;
+		goto cleanup;
 	}
 
 	ret = uci_cmd(argc - 1, argv + 1);
@@ -775,6 +860,7 @@ int main(int argc, char **argv)
 	if (ret == 255)
 		uci_usage();
 
+cleanup:
 	uci_free_context(ctx);
 
 	return ret;

--- a/delta.c
+++ b/delta.c
@@ -33,7 +33,7 @@
 
 /* record a change that was done to a package */
 void
-uci_add_delta(struct uci_context *ctx, struct uci_list *list, int cmd, const char *section, const char *option, const char *value)
+uci_add_delta(struct uci_context *ctx, struct uci_list *list, int cmd, const char *section, const char *option, const char *value, const char *comment)
 {
 	struct uci_delta *h;
 	int size = strlen(section) + 1;
@@ -42,7 +42,7 @@ uci_add_delta(struct uci_context *ctx, struct uci_list *list, int cmd, const cha
 	if (value)
 		size += strlen(value) + 1;
 
-	h = uci_alloc_element(ctx, delta, option, size);
+	h = uci_alloc_element(ctx, (ctx->flags & UCI_FLAG_NO_COMMENTS) ? NULL : comment, delta, option, size);
 	ptr = uci_dataptr(h);
 	h->cmd = cmd;
 	h->section = strcpy(ptr, section);
@@ -64,6 +64,33 @@ uci_free_delta(struct uci_delta *h)
 		free(h->value);
 	}
 	uci_free_element(&h->e);
+}
+
+static void uci_fprintf_escaped_comment(FILE *f, const char *comment)
+{
+	if (!comment || !comment[0])
+		return;
+
+	/*
+	 * Older uci versions just ignore the '#' and everything behind it, up
+	 * to and including the newline, and expect the next change on the
+	 * next line.
+	 * To be compatible with those older versions, we do not output
+	 * multiline strings here. Instead, we escape '\\' and '\n' in the
+	 * comment. Older versions will then work, just not put the comments
+	 * in the configuration file.
+	 */
+	fputc('#', f);
+	for (const char *readptr = comment; *readptr; readptr++) {
+		if (*readptr == '\\') {
+			fputc('\\', f);
+			fputc('\\', f);
+		} else if (*readptr == '\n') {
+			fputc('\\', f);
+			fputc('n', f);
+		} else
+			fputc(*readptr, f);
+	}
 }
 
 static void uci_delta_save(struct uci_context *ctx, FILE *f,
@@ -92,7 +119,9 @@ static void uci_delta_save(struct uci_context *ctx, FILE *f,
 			else
 				fprintf(f, "'\\''");
 		}
-		fprintf(f, "'\n");
+		fprintf(f, "'");
+		uci_fprintf_escaped_comment(f, e->comment);
+		fprintf(f, "\n");
 	}
 }
 
@@ -114,7 +143,7 @@ int uci_set_savedir(struct uci_context *ctx, const char *dir)
 		}
 	}
 	if (!exists)
-		e = uci_alloc_generic(ctx, UCI_TYPE_PATH, dir, sizeof(struct uci_element));
+		e = uci_alloc_generic(ctx, NULL, UCI_TYPE_PATH, dir, sizeof(struct uci_element));
 	uci_list_add(&ctx->delta_path, &e->list);
 
 	sdir = uci_strdup(ctx, dir);
@@ -138,7 +167,7 @@ int uci_add_delta_path(struct uci_context *ctx, const char *dir)
 			UCI_THROW(ctx, UCI_ERR_DUPLICATE);
 	}
 
-	e = uci_alloc_generic(ctx, UCI_TYPE_PATH, dir, sizeof(struct uci_element));
+	e = uci_alloc_generic(ctx, NULL, UCI_TYPE_PATH, dir, sizeof(struct uci_element));
 	/* Keep savedir at the end of ctx->delta_path list */
 	savedir = ctx->delta_path.prev;
 	uci_list_insert(savedir->prev, &e->list);
@@ -177,6 +206,8 @@ static inline int uci_parse_delta_tuple(struct uci_context *ctx, struct uci_ptr 
 		arg += 1;
 
 	UCI_INTERNAL(uci_parse_ptr, ctx, ptr, arg);
+	if (!ptr->comment && pctx->commentbuf)
+		ptr->comment = pctx->commentbuf;
 
 	if (!ptr->section)
 		goto error;
@@ -221,7 +252,7 @@ static void uci_parse_delta_line(struct uci_context *ctx, struct uci_package *p)
 		goto error;
 
 	if (ctx->flags & UCI_FLAG_SAVED_DELTA)
-		uci_add_delta(ctx, &p->saved_delta, cmd, ptr.section, ptr.option, ptr.value);
+		uci_add_delta(ctx, &p->saved_delta, cmd, ptr.section, ptr.option, ptr.value, ptr.comment);
 
 	switch(cmd) {
 	case UCI_CMD_REORDER:
@@ -393,7 +424,7 @@ static void uci_filter_delta(struct uci_context *ctx, const char *name, const ch
 
 		if (!match && ptr.section) {
 			uci_add_delta(ctx, &list, c,
-				ptr.section, ptr.option, ptr.value);
+				ptr.section, ptr.option, ptr.value, ptr.comment);
 		}
 	}
 

--- a/file.c
+++ b/file.c
@@ -113,6 +113,88 @@ static void skip_whitespace(struct uci_context *ctx)
 		pctx->pos += 1;
 }
 
+static void uci_comment_append(struct uci_context *ctx, const char *comment)
+{
+	struct uci_parse_context *pctx = ctx->pctx;
+	const size_t len = strlen(comment);
+	const size_t requiredsz = pctx->commentlen + len + 1;
+
+	if (requiredsz > pctx->commentbufsz) {
+		pctx->commentbufsz *= 2;
+		if (requiredsz > pctx->commentbufsz)
+			pctx->commentbufsz = requiredsz;
+		pctx->commentbuf = uci_realloc(ctx, pctx->commentbuf, pctx->commentbufsz);
+	}
+
+	memcpy(pctx->commentbuf + pctx->commentlen, comment, len + 1);
+	pctx->commentlen += len;
+}
+
+/*
+ * parse a comment line before a non-comment line
+ * pctx position must be at '#'
+ */
+static void uci_parse_comment_before(struct uci_context *ctx)
+{
+	UCI_ASSERT(ctx, pctx_cur_char(ctx->pctx) == '#');
+
+	uci_comment_append(ctx, pctx_cur_str(ctx->pctx));
+}
+
+/*
+ * parse a comment at the end of a non-comment line
+ * pctx position must be at '#'
+ */
+static void uci_parse_comment_after(struct uci_context *ctx)
+{
+	struct uci_parse_context *pctx = ctx->pctx;
+	const size_t len = strlen(pctx_cur_str(pctx));
+
+	UCI_ASSERT(ctx, pctx_cur_char(pctx) == '#');
+
+	/* cut off newline if present: this indicates that it's a comment
+	 * at the end of the non-comment line instead of a comment line
+	 * before the non-comment line. */
+	if (pctx_cur_str(pctx)[len - 1] == '\n')
+		pctx_cur_str(pctx)[len - 1] = '\0';
+
+	uci_comment_append(ctx, pctx_cur_str(pctx));
+}
+
+static void uci_fprintf_comment_before(struct uci_context const *ctx, FILE *stream, const char *indent, const char *comment)
+{
+	if ((!(ctx->flags & UCI_FLAG_NO_COMMENTS)) && comment && comment[0]) {
+		char *newline_ptr = strrchr(comment, '\n');
+		if (newline_ptr) {
+			fprintf(stream, "%s", indent);
+			for (const char *readptr = comment; readptr <= newline_ptr; readptr++) {
+				putc(*readptr, stream);
+				if (*readptr == '\n' && readptr != newline_ptr)
+					fprintf(stream, "%s", indent);
+			}
+		}
+	}
+}
+
+static void uci_fprintf_comment_after(struct uci_context const *ctx, FILE *stream, const char *comment)
+{
+	if ((!(ctx->flags & UCI_FLAG_NO_COMMENTS)) && comment && comment[0]) {
+		const char *ptr = strrchr(comment, '\n');
+		ptr = ptr ? (ptr + 1) : comment;
+		if (*ptr)
+			fprintf(stream, " %s", ptr);
+	}
+}
+
+static void uci_reset_comment(struct uci_context *ctx)
+{
+	struct uci_parse_context *pctx = ctx->pctx;
+
+	if (pctx->commentbuf)
+		pctx->commentbuf[0] = '\0';
+	pctx->commentlen = 0;
+}
+
 static inline void addc(struct uci_context *ctx, size_t *pos_dest, size_t *pos_src)
 {
 	struct uci_parse_context *pctx = ctx->pctx;
@@ -211,6 +293,8 @@ static void parse_str(struct uci_context *ctx, size_t *target)
 			parse_double_quote(ctx, target);
 			break;
 		case '#':
+			if (!(ctx->flags & UCI_FLAG_NO_COMMENTS))
+				uci_parse_comment_after(ctx);
 			pctx_cur_char(pctx) = 0;
 			/* fall through */
 		case 0:
@@ -270,6 +354,35 @@ done:
 	return val;
 }
 
+static void uci_unescape_comment(char *comment, bool skip_hash)
+{
+	char *readptr = comment;
+	char *writeptr = comment;
+
+	if (skip_hash && *readptr == '#')
+		readptr++;
+
+	while (*readptr) {
+		if (*readptr != '\\')
+			*writeptr = *readptr;
+		else {
+			if (readptr[1] == '\\') {
+				*writeptr = '\\';
+				readptr++;
+			}
+			else if (readptr[1] == 'n') {
+				*writeptr = '\n';
+				readptr++;
+			}
+			else
+				*writeptr = '\\';
+		}
+		readptr++;
+		writeptr++;
+	}
+	*writeptr = '\0';
+}
+
 int uci_parse_argument(struct uci_context *ctx, FILE *stream, char **str, char **result)
 {
 	int ofs_result;
@@ -290,9 +403,16 @@ int uci_parse_argument(struct uci_context *ctx, FILE *stream, char **str, char *
 		uci_getln(ctx, 0);
 	}
 
+	uci_reset_comment(ctx);
+
 	ofs_result = next_arg(ctx, false, false, false);
 	*result = pctx_str(ctx->pctx, ofs_result);
 	*str = pctx_cur_str(ctx->pctx);
+
+	if (ctx->pctx->commentbuf) {
+		uci_unescape_comment(ctx->pctx->commentbuf, true);
+		ctx->pctx->commentlen = strlen(ctx->pctx->commentbuf);
+	}
 
 	return 0;
 }
@@ -354,7 +474,7 @@ static void assert_eol(struct uci_context *ctx)
  * switch to a different config, either triggered by uci_load, or by a
  * 'package <...>' statement in the import file
  */
-static void uci_switch_config(struct uci_context *ctx)
+static void uci_switch_config(struct uci_context *ctx, bool with_comment)
 {
 	struct uci_parse_context *pctx;
 	struct uci_element *e;
@@ -382,7 +502,7 @@ static void uci_switch_config(struct uci_context *ctx)
 	e = uci_lookup_list(&ctx->root, name);
 	if (e)
 		UCI_THROW(ctx, UCI_ERR_DUPLICATE);
-	pctx->package = uci_alloc_package(ctx, name);
+	pctx->package = uci_alloc_package(ctx, with_comment ? pctx->commentbuf : NULL, name);
 }
 
 /*
@@ -401,11 +521,12 @@ static void uci_parse_package(struct uci_context *ctx, bool single)
 	ofs_name = next_arg(ctx, true, true, true);
 	assert_eol(ctx);
 	name = pctx_str(pctx, ofs_name);
-	if (single)
-		return;
+	if (!single) {
+		ctx->pctx->name = name;
+		uci_switch_config(ctx, true);
+	}
 
-	ctx->pctx->name = name;
-	uci_switch_config(ctx);
+	uci_reset_comment(ctx);
 }
 
 /*
@@ -424,7 +545,7 @@ static void uci_parse_config(struct uci_context *ctx)
 		if (!ctx->pctx->name)
 			uci_parse_error(ctx, "attempting to import a file without a package name");
 
-		uci_switch_config(ctx);
+		uci_switch_config(ctx, false);
 	}
 
 	/* command string null-terminated by strtok */
@@ -443,7 +564,7 @@ static void uci_parse_config(struct uci_context *ctx)
 
 	if (!name || !name[0]) {
 		ctx->internal = !pctx->merge;
-		UCI_NESTED(uci_add_section, ctx, pctx->package, type, &pctx->section);
+		UCI_NESTED(uci_add_section_with_comment, ctx, pctx->package, pctx->commentbuf, type, &pctx->section);
 	} else {
 		uci_fill_ptr(ctx, &ptr, &pctx->package->e);
 		e = uci_lookup_list(&pctx->package->sections, name);
@@ -454,6 +575,7 @@ static void uci_parse_config(struct uci_context *ctx)
 				uci_parse_error(ctx, "section of different type overwrites prior section with same name");
 		}
 
+		ptr.comment = pctx->commentbuf;
 		ptr.section = name;
 		ptr.value = type;
 
@@ -461,6 +583,8 @@ static void uci_parse_config(struct uci_context *ctx)
 		UCI_NESTED(uci_set, ctx, &ptr);
 		pctx->section = ptr.s;
 	}
+
+	uci_reset_comment(ctx);
 }
 
 /*
@@ -492,6 +616,7 @@ static void uci_parse_option(struct uci_context *ctx, bool list)
 	e = uci_lookup_list(&pctx->section->options, name);
 	if (e)
 		ptr.o = uci_to_option(e);
+	ptr.comment = pctx->commentbuf;
 	ptr.option = name;
 	ptr.value = value;
 
@@ -500,6 +625,8 @@ static void uci_parse_option(struct uci_context *ctx, bool list)
 		UCI_NESTED(uci_add_list, ctx, &ptr);
 	else
 		UCI_NESTED(uci_set, ctx, &ptr);
+
+	uci_reset_comment(ctx);
 }
 
 /*
@@ -512,6 +639,14 @@ static void uci_parse_line(struct uci_context *ctx, bool single)
 
 	/* Skip whitespace characters at the start of line */
 	skip_whitespace(ctx);
+
+	/* Keep comment line as is, do not tokenize */
+	if (pctx_cur_char(pctx) == '#') {
+		if (!(ctx->flags & UCI_FLAG_NO_COMMENTS))
+			uci_parse_comment_before(ctx);
+		return;
+	}
+
 	do {
 		word = strtok(pctx_cur_str(pctx), " \t");
 		if (!word)
@@ -612,25 +747,38 @@ static void uci_export_package(struct uci_package *p, FILE *stream, bool header)
 	struct uci_context *ctx = p->ctx;
 	struct uci_element *s, *o, *i;
 
-	if (header)
-		fprintf(stream, "package %s\n", uci_escape(ctx, p->e.name));
+	if (header) {
+		uci_fprintf_comment_before(ctx, stream, "", p->e.comment);
+		fprintf(stream, "package %s", uci_escape(ctx, p->e.name));
+		uci_fprintf_comment_after(ctx, stream, p->e.comment);
+		fprintf(stream, "\n");
+	}
 	uci_foreach_element(&p->sections, s) {
 		struct uci_section *sec = uci_to_section(s);
-		fprintf(stream, "\nconfig %s", uci_escape(ctx, sec->type));
+		fprintf(stream, "\n");
+		uci_fprintf_comment_before(ctx, stream, "", sec->e.comment);
+		fprintf(stream, "config %s", uci_escape(ctx, sec->type));
 		if (!sec->anonymous || (ctx->flags & UCI_FLAG_EXPORT_NAME))
 			fprintf(stream, " '%s'", uci_escape(ctx, sec->e.name));
+		uci_fprintf_comment_after(ctx, stream, sec->e.comment);
 		fprintf(stream, "\n");
 		uci_foreach_element(&sec->options, o) {
 			struct uci_option *opt = uci_to_option(o);
 			switch(opt->type) {
 			case UCI_TYPE_STRING:
+				uci_fprintf_comment_before(ctx, stream, "\t", opt->e.comment);
 				fprintf(stream, "\toption %s", uci_escape(ctx, opt->e.name));
-				fprintf(stream, " '%s'\n", uci_escape(ctx, opt->v.string));
+				fprintf(stream, " '%s'", uci_escape(ctx, opt->v.string));
+				uci_fprintf_comment_after(ctx, stream, opt->e.comment);
+				fprintf(stream, "\n");
 				break;
 			case UCI_TYPE_LIST:
 				uci_foreach_element(&opt->v.list, i) {
+					uci_fprintf_comment_before(ctx, stream, "\t", i->comment);
 					fprintf(stream, "\tlist %s", uci_escape(ctx, opt->e.name));
-					fprintf(stream, " '%s'\n", uci_escape(ctx, i->name));
+					fprintf(stream, " '%s'", uci_escape(ctx, i->name));
+					uci_fprintf_comment_after(ctx, stream, i->comment);
+					fprintf(stream, "\n");
 				}
 				break;
 			default:
@@ -703,14 +851,14 @@ error:
 	}
 
 	if (!pctx->package && name)
-		uci_switch_config(ctx);
+		uci_switch_config(ctx, false);
 	if (package)
 		*package = pctx->package;
 	if (pctx->merge)
 		pctx->package = NULL;
 
 	pctx->name = NULL;
-	uci_switch_config(ctx);
+	uci_switch_config(ctx, false);
 
 	/* no error happened, we can get rid of the parser context now */
 	uci_cleanup(ctx);

--- a/libuci.c
+++ b/libuci.c
@@ -142,6 +142,9 @@ __private void uci_cleanup(struct uci_context *ctx)
 	if (pctx->package)
 		uci_free_package(&pctx->package);
 
+	if (pctx->commentbuf)
+		free(pctx->commentbuf);
+
 	if (pctx->buf)
 		free(pctx->buf);
 

--- a/list.c
+++ b/list.c
@@ -35,7 +35,7 @@ static bool uci_list_set_pos(struct uci_list *head, struct uci_list *ptr, int po
  * payload is appended to the struct to save memory and reduce fragmentation
  */
 __private struct uci_element *
-uci_alloc_generic(struct uci_context *ctx, int type, const char *name, int size)
+uci_alloc_generic(struct uci_context *ctx, const char *comment, int type, const char *name, int size)
 {
 	struct uci_element *e;
 	int datalen = size;
@@ -43,6 +43,13 @@ uci_alloc_generic(struct uci_context *ctx, int type, const char *name, int size)
 
 	ptr = uci_malloc(ctx, datalen);
 	e = (struct uci_element *) ptr;
+	if (comment && comment[0]) {
+		UCI_TRAP_SAVE(ctx, error);
+		if (!uci_validate_comment(comment))
+			UCI_THROW(ctx, UCI_ERR_INVAL);
+		e->comment = uci_strdup(ctx, comment);
+		UCI_TRAP_RESTORE(ctx);
+	}
 	e->type = type;
 	if (name) {
 		UCI_TRAP_SAVE(ctx, error);
@@ -53,6 +60,7 @@ uci_alloc_generic(struct uci_context *ctx, int type, const char *name, int size)
 	goto done;
 
 error:
+	free(e->comment);
 	free(ptr);
 	UCI_THROW(ctx, ctx->err);
 
@@ -60,9 +68,39 @@ done:
 	return e;
 }
 
+static void
+uci_update_str(struct uci_context *ctx, char **pstr, const char *new)
+{
+	if (*pstr && new && new[0] && strlen(*pstr) >= strlen(new)) {
+		strcpy(*pstr, new);
+	} else {
+		if (*pstr) {
+			free(*pstr);
+			*pstr = NULL;
+		}
+
+		if (new && new[0]) {
+			UCI_TRAP_SAVE(ctx, error);
+			*pstr = uci_strdup(ctx, new);
+			UCI_TRAP_RESTORE(ctx);
+		}
+	}
+
+	return;
+error:
+	UCI_THROW(ctx, ctx->err);
+}
+
+static void
+uci_update_generic(struct uci_context *ctx, struct uci_element *e, const char *comment)
+{
+	uci_update_str(ctx, &(e->comment), comment);
+}
+
 __private void
 uci_free_element(struct uci_element *e)
 {
+	free(e->comment);
 	free(e->name);
 	if (!uci_list_empty(&e->list))
 		uci_list_del(&e->list);
@@ -70,13 +108,13 @@ uci_free_element(struct uci_element *e)
 }
 
 static struct uci_option *
-uci_alloc_option(struct uci_section *s, const char *name, const char *value, struct uci_list *after)
+uci_alloc_option(struct uci_section *s, const char *comment, const char *name, const char *value, struct uci_list *after)
 {
 	struct uci_package *p = s->package;
 	struct uci_context *ctx = p->ctx;
 	struct uci_option *o;
 
-	o = uci_alloc_element(ctx, option, name, strlen(value) + 1);
+	o = uci_alloc_element(ctx, comment, option, name, strlen(value) + 1);
 	o->type = UCI_TYPE_STRING;
 	o->v.string = uci_dataptr(o);
 	o->section = s;
@@ -84,6 +122,22 @@ uci_alloc_option(struct uci_section *s, const char *name, const char *value, str
 	uci_list_insert(after ? after : s->options.prev, &o->e.list);
 
 	return o;
+}
+
+/*
+ * Attempts to update the option without having to reallocate.
+ * Returns false on failure, in which case nothing was updated.
+ * Returns true on success.
+ */
+static bool
+uci_try_update_option(struct uci_context *ctx, struct uci_option *o, const char *comment, const char *value)
+{
+	if (o->type != UCI_TYPE_STRING || strlen(o->v.string) < strlen(value))
+		return false;
+
+	strcpy(o->v.string, value);
+	uci_update_generic(ctx, &(o->e), comment);
+	return true;
 }
 
 static inline void
@@ -109,13 +163,13 @@ uci_free_option(struct uci_option *o)
 }
 
 static struct uci_option *
-uci_alloc_list(struct uci_section *s, const char *name, struct uci_list *after)
+uci_alloc_list(struct uci_section *s, const char *comment, const char *name, struct uci_list *after)
 {
 	struct uci_package *p = s->package;
 	struct uci_context *ctx = p->ctx;
 	struct uci_option *o;
 
-	o = uci_alloc_element(ctx, option, name, 0);
+	o = uci_alloc_element(ctx, comment, option, name, 0);
 	o->type = UCI_TYPE_LIST;
 	o->section = s;
 	uci_list_init(&o->v.list);
@@ -195,7 +249,7 @@ static void uci_section_transfer_options(struct uci_section *dst, struct uci_sec
 }
 
 static struct uci_section *
-uci_alloc_section(struct uci_package *p, const char *type, const char *name, struct uci_list *after)
+uci_alloc_section(struct uci_package *p, const char *comment, const char *type, const char *name, struct uci_list *after)
 {
 	struct uci_context *ctx = p->ctx;
 	struct uci_section *s;
@@ -203,7 +257,7 @@ uci_alloc_section(struct uci_package *p, const char *type, const char *name, str
 	if (name && !name[0])
 		name = NULL;
 
-	s = uci_alloc_element(ctx, section, name, strlen(type) + 1);
+	s = uci_alloc_element(ctx, comment, section, name, strlen(type) + 1);
 	uci_list_init(&s->options);
 	s->type = uci_dataptr(s);
 	s->package = p;
@@ -215,6 +269,23 @@ uci_alloc_section(struct uci_package *p, const char *type, const char *name, str
 	uci_list_insert(after ? after : p->sections.prev, &s->e.list);
 
 	return s;
+}
+
+/*
+ * Attempts to update the section without having to reallocate.
+ * Returns false on failure, in which case nothing was updated.
+ * Returns true on success.
+ */
+static bool
+uci_try_update_section(struct uci_context *ctx, struct uci_section *s, const char *comment, const char *type)
+{
+	if (strlen(s->type) < strlen(type))
+		/* need to realloc entire option */
+		return false;
+
+	strcpy(s->type, type);
+	uci_update_generic(ctx, &(s->e), comment);
+	return true;
 }
 
 static void
@@ -232,11 +303,11 @@ uci_free_section(struct uci_section *s)
 }
 
 __private struct uci_package *
-uci_alloc_package(struct uci_context *ctx, const char *name)
+uci_alloc_package(struct uci_context *ctx, const char *comment, const char *name)
 {
 	struct uci_package *p;
 
-	p = uci_alloc_element(ctx, package, name, 0);
+	p = uci_alloc_element(ctx, comment, package, name, 0);
 	p->ctx = ctx;
 	uci_list_init(&p->sections);
 	uci_list_init(&p->delta);
@@ -500,7 +571,7 @@ int uci_rename(struct uci_context *ctx, struct uci_ptr *ptr)
 	UCI_ASSERT(ctx, ptr->value);
 
 	if (!internal && p->has_delta)
-		uci_add_delta(ctx, &p->delta, UCI_CMD_RENAME, ptr->section, ptr->option, ptr->value);
+		uci_add_delta(ctx, &p->delta, UCI_CMD_RENAME, ptr->section, ptr->option, ptr->value, NULL);
 
 	n = uci_strdup(ctx, ptr->value);
 	free(e->name);
@@ -524,27 +595,33 @@ int uci_reorder_section(struct uci_context *ctx, struct uci_section *s, int pos)
 	changed = uci_list_set_pos(&s->package->sections, &s->e.list, pos);
 	if (!internal && p->has_delta && changed) {
 		sprintf(order, "%d", pos);
-		uci_add_delta(ctx, &p->delta, UCI_CMD_REORDER, s->e.name, NULL, order);
+		uci_add_delta(ctx, &p->delta, UCI_CMD_REORDER, s->e.name, NULL, order, NULL);
 	}
 
 	return 0;
 }
 
-int uci_add_section(struct uci_context *ctx, struct uci_package *p, const char *type, struct uci_section **res)
+__private int
+uci_add_section_with_comment(struct uci_context *ctx, struct uci_package *p, const char *comment, const char *type, struct uci_section **res)
 {
 	bool internal = ctx && ctx->internal;
 	struct uci_section *s;
 
 	UCI_HANDLE_ERR(ctx);
 	UCI_ASSERT(ctx, p != NULL);
-	s = uci_alloc_section(p, type, NULL, NULL);
+	s = uci_alloc_section(p, comment, type, NULL, NULL);
 	if (s && s->anonymous)
 		uci_fixup_section(ctx, s);
 	*res = s;
 	if (!internal && p->has_delta)
-		uci_add_delta(ctx, &p->delta, UCI_CMD_ADD, s->e.name, NULL, type);
+		uci_add_delta(ctx, &p->delta, UCI_CMD_ADD, s->e.name, NULL, type, s->e.comment);
 
 	return 0;
+}
+
+int uci_add_section(struct uci_context *ctx, struct uci_package *p, const char *type, struct uci_section **res)
+{
+	return uci_add_section_with_comment(ctx, p, NULL, type, res);
 }
 
 int uci_delete(struct uci_context *ctx, struct uci_ptr *ptr)
@@ -569,7 +646,7 @@ int uci_delete(struct uci_context *ctx, struct uci_ptr *ptr)
 		uci_foreach_element_safe(&ptr->o->v.list, tmp, e2) {
 			if (index == 0) {
 				if (!internal && p->has_delta)
-					uci_add_delta(ctx, &p->delta, UCI_CMD_REMOVE, ptr->section, ptr->option, ptr->value);
+					uci_add_delta(ctx, &p->delta, UCI_CMD_REMOVE, ptr->section, ptr->option, ptr->value, NULL);
 				uci_free_option(uci_to_option(e2));
 				return 0;
 			}
@@ -580,7 +657,7 @@ int uci_delete(struct uci_context *ctx, struct uci_ptr *ptr)
 	}
 
 	if (!internal && p->has_delta)
-		uci_add_delta(ctx, &p->delta, UCI_CMD_REMOVE, ptr->section, ptr->option, NULL);
+		uci_add_delta(ctx, &p->delta, UCI_CMD_REMOVE, ptr->section, ptr->option, NULL, NULL);
 
 	uci_free_any(&e1);
 
@@ -609,19 +686,19 @@ int uci_add_list(struct uci_context *ctx, struct uci_ptr *ptr)
 	}
 
 	/* create new item */
-	e1 = uci_alloc_generic(ctx, UCI_TYPE_ITEM, ptr->value, sizeof(struct uci_option));
+	e1 = uci_alloc_generic(ctx, ptr->comment, UCI_TYPE_ITEM, ptr->value, sizeof(struct uci_option));
 
 	if (!ptr->o) {
 		/* create new list */
 		UCI_TRAP_SAVE(ctx, error);
-		ptr->o = uci_alloc_list(ptr->s, ptr->option, NULL);
+		ptr->o = uci_alloc_list(ptr->s, ptr->comment, ptr->option, NULL);
 		UCI_TRAP_RESTORE(ctx);
 	} else if (ptr->o->type == UCI_TYPE_STRING) {
 		/* create new list and add old string value as item to list */
 		struct uci_option *old = ptr->o;
 		UCI_TRAP_SAVE(ctx, error);
-		e2 = uci_alloc_generic(ctx, UCI_TYPE_ITEM, old->v.string, sizeof(struct uci_option));
-		ptr->o = uci_alloc_list(ptr->s, ptr->option, &old->e.list);
+		e2 = uci_alloc_generic(ctx, old->e.comment, UCI_TYPE_ITEM, old->v.string, sizeof(struct uci_option));
+		ptr->o = uci_alloc_list(ptr->s, ptr->comment, ptr->option, &old->e.list);
 		UCI_TRAP_RESTORE(ctx);
 		uci_list_add(&ptr->o->v.list, &e2->list);
 
@@ -635,7 +712,7 @@ int uci_add_list(struct uci_context *ctx, struct uci_ptr *ptr)
 	uci_list_add(&ptr->o->v.list, &e1->list);
 
 	if (!internal && ptr->p->has_delta)
-		uci_add_delta(ctx, &ptr->p->delta, UCI_CMD_LIST_ADD, ptr->section, ptr->option, ptr->value);
+		uci_add_delta(ctx, &ptr->p->delta, UCI_CMD_LIST_ADD, ptr->section, ptr->option, ptr->value, ptr->comment);
 
 	return 0;
 error:
@@ -667,7 +744,7 @@ int uci_del_list(struct uci_context *ctx, struct uci_ptr *ptr)
 
 	p = ptr->p;
 	if (!internal && p->has_delta)
-		uci_add_delta(ctx, &p->delta, UCI_CMD_LIST_DEL, ptr->section, ptr->option, ptr->value);
+		uci_add_delta(ctx, &p->delta, UCI_CMD_LIST_DEL, ptr->section, ptr->option, ptr->value, NULL);
 
 	uci_foreach_element_safe(&ptr->o->v.list, tmp, e) {
 		if (!strcmp(ptr->value, uci_to_option(e)->e.name)) {
@@ -705,31 +782,23 @@ int uci_set(struct uci_context *ctx, struct uci_ptr *ptr)
 
 		return uci_delete(ctx, ptr);
 	} else if (!ptr->o && ptr->option) { /* new option */
-		ptr->o = uci_alloc_option(ptr->s, ptr->option, ptr->value, NULL);
+		ptr->o = uci_alloc_option(ptr->s, ptr->comment, ptr->option, ptr->value, NULL);
 	} else if (!ptr->s && ptr->section) { /* new section */
-		ptr->s = uci_alloc_section(ptr->p, ptr->value, ptr->section, NULL);
+		ptr->s = uci_alloc_section(ptr->p, ptr->comment, ptr->value, ptr->section, NULL);
 	} else if (ptr->o && ptr->option) { /* update option */
-		if (ptr->o->type == UCI_TYPE_STRING && !strcmp(ptr->o->v.string, ptr->value))
-			return 0;
-
-		if (ptr->o->type == UCI_TYPE_STRING && strlen(ptr->o->v.string) == strlen(ptr->value)) {
-			strcpy(ptr->o->v.string, ptr->value);
-		} else {
+		/* value, list values, comment may have changed */
+		if (!uci_try_update_option(ctx, ptr->o, ptr->comment, ptr->value)) {
 			struct uci_option *old = ptr->o;
-			ptr->o = uci_alloc_option(ptr->s, ptr->option, ptr->value, &old->e.list);
+			ptr->o = uci_alloc_option(ptr->s, ptr->comment, ptr->option, ptr->value, &old->e.list);
 			if (ptr->option == old->e.name)
 				ptr->option = ptr->o->e.name;
 			uci_free_option(old);
 		}
 	} else if (ptr->s && ptr->section) { /* update section */
-		if (!strcmp(ptr->s->type, ptr->value))
-			return 0;
-
-		if (strlen(ptr->s->type) == strlen(ptr->value)) {
-			strcpy(ptr->s->type, ptr->value);
-		} else {
+		/* type, comment may have changed */
+		if (!uci_try_update_section(ctx, ptr->s, ptr->comment, ptr->value)) {
 			struct uci_section *old = ptr->s;
-			ptr->s = uci_alloc_section(ptr->p, ptr->value, old->e.name, &old->e.list);
+			ptr->s = uci_alloc_section(ptr->p, old->e.comment, ptr->value, old->e.name, &old->e.list);
 			uci_section_transfer_options(ptr->s, old);
 			if (ptr->section == old->e.name)
 				ptr->section = ptr->s->e.name;
@@ -741,7 +810,7 @@ int uci_set(struct uci_context *ctx, struct uci_ptr *ptr)
 	}
 
 	if (!internal && ptr->p->has_delta)
-		uci_add_delta(ctx, &ptr->p->delta, UCI_CMD_CHANGE, ptr->section, ptr->option, ptr->value);
+		uci_add_delta(ctx, &ptr->p->delta, UCI_CMD_CHANGE, ptr->section, ptr->option, ptr->value, ptr->comment);
 
 	return 0;
 }

--- a/scripts/devel-build.sh
+++ b/scripts/devel-build.sh
@@ -87,6 +87,10 @@ make -C "${BUILDDIR}" test CTEST_OUTPUT_ON_FAILURE=1
 
 set +x
 echo "✅ Success - uci is available at ${BUILDDIR}"
+echo "👷 The test log is available at ${BUILDDIR}/Testing/Temporary/LastTest.log"
 echo "👷 You can rebuild uci by running 'make -C build'"
+echo "👷 To run a specific shunit2 test, set SHUNIT2_TEST_TO_RUN. For example:"
+echo "   SHUNIT2_TEST_TO_RUN=test_delete_option $0"
+echo ""
 
 exit 0

--- a/tests/shunit2/references/add_list_keep_comments.data
+++ b/tests/shunit2/references/add_list_keep_comments.data
@@ -1,0 +1,23 @@
+# before
+config named 'section'
+	# before
+	option opt 'val'
+
+	option opt2 'val2' # after1
+
+	#before1
+	#before2
+	option opt3 'val3' # after2
+
+config named 'section2' # after3
+
+#before3
+#before4
+config named 'section3' # after4
+
+#before5
+#before6
+config named 'section4' # after5
+	#before7
+	#before8
+	option opt3 'val3' # after6

--- a/tests/shunit2/references/add_list_keep_comments.result
+++ b/tests/shunit2/references/add_list_keep_comments.result
@@ -1,0 +1,25 @@
+
+# before
+config named 'section'
+	# before
+	option opt 'val'
+	option opt2 'val2' # after1
+	#before1
+	#before2
+	option opt3 'val3' # after2
+	list listopt 'val'
+	list listopt 'val2'
+
+config named 'section2' # after3
+
+#before3
+#before4
+config named 'section3' # after4
+
+#before5
+#before6
+config named 'section4' # after5
+	#before7
+	#before8
+	option opt3 'val3' # after6
+

--- a/tests/shunit2/references/add_list_keep_comments2.changes
+++ b/tests/shunit2/references/add_list_keep_comments2.changes
@@ -1,0 +1,6 @@
+|test.section.listopt='val'##before1\n
+|test.section.listopt='val2'##before1\n#before2\n
+|test.section.listopt='val3'##after
+|test.section.listopt='val4'##before1\n#after
+|test.section.listopt='val5'##before1\n#before2\n#after
+|test.section.listopt='val6'##be\\fore1\n#be\\fore2\n#af\\ter

--- a/tests/shunit2/references/add_list_keep_comments2.result
+++ b/tests/shunit2/references/add_list_keep_comments2.result
@@ -1,0 +1,17 @@
+
+config named 'section'
+	#before1
+	list listopt 'val'
+	#before1
+	#before2
+	list listopt 'val2'
+	list listopt 'val3' #after
+	#before1
+	list listopt 'val4' #after
+	#before1
+	#before2
+	list listopt 'val5' #after
+	#be\fore1
+	#be\fore2
+	list listopt 'val6' #af\ter
+

--- a/tests/shunit2/references/add_list_parsing.data
+++ b/tests/shunit2/references/add_list_parsing.data
@@ -1,0 +1,2 @@
+config type 'section'
+	list opt 'val'

--- a/tests/shunit2/references/batch_keep_comments.result
+++ b/tests/shunit2/references/batch_keep_comments.result
@@ -1,0 +1,7 @@
+
+config section 'SEC0' # comment after section
+	# comment before interface
+	option interface 'home' # comment after interface
+	# comment before listopt
+	list listopt 'listitem'
+

--- a/tests/shunit2/references/batch_keep_comments_output.result
+++ b/tests/shunit2/references/batch_keep_comments_output.result
@@ -1,0 +1,6 @@
+home
+home
+'# comment before interface
+# comment after interface'
+'# comment before interface
+# comment after interface'

--- a/tests/shunit2/references/changes_keep_comments.result
+++ b/tests/shunit2/references/changes_keep_comments.result
@@ -1,0 +1,8 @@
+test.section1='type'
+test.section1.opt1='val'
+test.section1.listopt1+='listval1'
+test.section1.listopt1+='listval2'
+test.section2='type'## before section2\n# after section2
+test.section2.opt1='val'## before section2.opt1\n# after section2.opt1
+test.section2.listopt1+='listval1'## before section2.listopt1\n
+test.section2.listopt1+='listval2'## af\\ter section2.listopt1

--- a/tests/shunit2/references/del_list_keep_comments.data
+++ b/tests/shunit2/references/del_list_keep_comments.data
@@ -1,0 +1,20 @@
+
+# comment before section
+config named 'section' # comment after section
+	# comment before opt
+	option opt 'optval' # comment after opt
+	#before1
+	list listopt 'val'
+	#before1
+	#before2
+	list listopt 'val2'
+	list listopt 'val3' #after
+	#before1
+	list listopt 'val4' #after
+	#before1
+	#before2
+	list listopt 'val5' #after
+	#be\fore1
+	#be\fore2
+	list listopt 'val6' #af\ter
+

--- a/tests/shunit2/references/del_list_keep_comments.result
+++ b/tests/shunit2/references/del_list_keep_comments.result
@@ -1,0 +1,6 @@
+
+# comment before section
+config named 'section' # comment after section
+	# comment before opt
+	option opt 'optval' # comment after opt
+

--- a/tests/shunit2/references/delete_option.data
+++ b/tests/shunit2/references/delete_option.data
@@ -1,0 +1,13 @@
+
+config type 'section1'
+	option opt 'val'
+	option opt2 'val2'
+	list listopt 'val3'
+	list listopt 'val4'
+
+config type 'section2'
+	option opt 'val'
+	option opt2 'val2'
+	list listopt 'val3'
+	list listopt 'val4'
+

--- a/tests/shunit2/references/delete_option.result
+++ b/tests/shunit2/references/delete_option.result
@@ -1,0 +1,10 @@
+
+config type 'section1'
+	option opt2 'val2'
+
+config type 'section2'
+	option opt 'val'
+	option opt2 'val2'
+	list listopt 'val3'
+	list listopt 'val4'
+

--- a/tests/shunit2/references/delete_option_keep_comments.data
+++ b/tests/shunit2/references/delete_option_keep_comments.data
@@ -1,0 +1,24 @@
+
+# comment 1
+config type 'section1' # comment 2
+	# comment 3
+	option opt 'val' # comment 4
+	option opt2 'val2' # comment 5
+# comment 6
+	list listopt 'val3' # comment 7
+	# comment 8
+	# comment 9
+	list listopt 'val4' # comment 10
+
+# comment 11
+#
+  # comment 12
+config type 'section2' # comment 13
+	option opt 'val'
+	# comment 14
+	# comment 15
+	option opt2 'val2'
+	list listopt 'val3' # comment 16
+	# comment 17
+	list listopt 'val4' # comment 18
+

--- a/tests/shunit2/references/delete_option_keep_comments.result
+++ b/tests/shunit2/references/delete_option_keep_comments.result
@@ -1,0 +1,17 @@
+
+# comment 1
+config type 'section1' # comment 2
+	option opt2 'val2' # comment 5
+
+# comment 11
+#
+# comment 12
+config type 'section2' # comment 13
+	option opt 'val'
+	# comment 14
+	# comment 15
+	option opt2 'val2'
+	list listopt 'val3' # comment 16
+	# comment 17
+	list listopt 'val4' # comment 18
+

--- a/tests/shunit2/references/delete_section.data
+++ b/tests/shunit2/references/delete_section.data
@@ -1,0 +1,12 @@
+config type 'section'
+	option opt 'val'
+	option opt2 'val2'
+
+config type 'section2'
+	option opt3 'val3'
+	option opt4 'val4'
+
+
+config type 'section3'
+	option opt3 'val5'
+	option opt4 'val6'

--- a/tests/shunit2/references/delete_section.result
+++ b/tests/shunit2/references/delete_section.result
@@ -1,0 +1,9 @@
+
+config type 'section'
+	option opt 'val'
+	option opt2 'val2'
+
+config type 'section3'
+	option opt3 'val5'
+	option opt4 'val6'
+

--- a/tests/shunit2/references/delete_section_keep_comments.data
+++ b/tests/shunit2/references/delete_section_keep_comments.data
@@ -1,0 +1,18 @@
+# comment 1
+# comment 2
+config type 'section' # comment 3
+	# comment 4
+	option opt 'val' # comment 5
+	option opt2 'val2' # comment 6 
+
+# comment 7
+config type 'section2' # comment 8
+	option opt3 'val3' # comment 9
+	# comment 10
+	option opt4 'val4' # comment 11
+
+ # comment 12
+config type 'section3'
+	option opt3 'val5'  # comment 13
+# comment 14
+	option opt4 'val6'

--- a/tests/shunit2/references/delete_section_keep_comments.result
+++ b/tests/shunit2/references/delete_section_keep_comments.result
@@ -1,0 +1,14 @@
+
+# comment 1
+# comment 2
+config type 'section' # comment 3
+	# comment 4
+	option opt 'val' # comment 5
+	option opt2 'val2' # comment 6 
+
+# comment 12
+config type 'section3'
+	option opt3 'val5' # comment 13
+	# comment 14
+	option opt4 'val6'
+

--- a/tests/shunit2/references/export_keep_comments.data
+++ b/tests/shunit2/references/export_keep_comments.data
@@ -1,0 +1,23 @@
+
+# lots
+             #  of
+	#   comment
+#    lines
+config 'type' 'section'
+	option 'opt' 'val'
+	list 'list_opt' 'val0'
+	list 'list_opt' 'val1'               	###### another comment after val1
+# lots
+             # more
+	# comment
+# lines
+	option mul_line_opt_sq 'line 1
+line 2 \
+line 3'
+	option mul_line_opt_dq "\"Hello\, \
+World.\'
+"
+
+# comment lines
+# that are
+# lost...

--- a/tests/shunit2/references/export_keep_comments.result
+++ b/tests/shunit2/references/export_keep_comments.result
@@ -1,0 +1,20 @@
+package export
+
+# lots
+#  of
+#   comment
+#    lines
+config type 'section'
+	option opt 'val'
+	list list_opt 'val0'
+	list list_opt 'val1' ###### another comment after val1
+	# lots
+	# more
+	# comment
+	# lines
+	option mul_line_opt_sq 'line 1
+line 2 \
+line 3'
+	option mul_line_opt_dq '"Hello, World.'\''
+'
+

--- a/tests/shunit2/references/get_option_keep_comments.data
+++ b/tests/shunit2/references/get_option_keep_comments.data
@@ -1,0 +1,44 @@
+config type 'section'
+	#before1
+	option opt1 'val1'
+
+	#before1
+	#before2
+	option opt2 'val2'
+
+	option opt3 'val3' #after
+
+	#before1
+	option opt4 'val4' #after
+
+	#before1
+
+	#before2
+	option opt5 'val5' #after
+
+	#be\fo're
+	option opt6 'val6' #af\te'r
+
+	option opt7 'val7'
+
+	#before1
+	list listopt 'vala'
+
+	#before1
+	#before2
+	list listopt 'valb'
+
+	list listopt 'valc' #after
+
+	#before1
+	list listopt 'vald' #after
+
+	#before1
+
+	#before2
+	list listopt 'valc' #after
+
+	#be\fo're
+	list listopt 'valf' #af\te'r
+
+	list listopt 'vala'

--- a/tests/shunit2/references/get_option_multiline_keep_comments.data
+++ b/tests/shunit2/references/get_option_multiline_keep_comments.data
@@ -1,0 +1,7 @@
+### comment1
+config 'type' 'section' ### comment2
+	# Can preserve trailing whitespace with assertEquals.
+	option opt "\"Hello, \
+World.
+  \'" ### comment4
+### comment5

--- a/tests/shunit2/references/get_parsing_keep_comments.data
+++ b/tests/shunit2/references/get_parsing_keep_comments.data
@@ -1,0 +1,11 @@
+# comment line before section
+config 'type' 'section' # comment line after section
+	# comment line before opt
+	option 'opt'	'val'#comment line after opt !@#$%^&*()_+[]{}
+# another comment
+
+# comment line before unnamed !@#$%^&*()_+[]{}
+config 'unnamed' # comment line after unnamed !@#$%^&*()_+[]{}
+	option 'opt1'	'val1' ## after val1
+
+# another comment at eof

--- a/tests/shunit2/references/get_section_keep_comments.data
+++ b/tests/shunit2/references/get_section_keep_comments.data
@@ -1,0 +1,21 @@
+#before1
+config typea section1
+
+#before1
+#before2
+config typeb section2
+
+config typec section3 #after
+
+#before1
+config typed section4 #after
+
+#before1
+
+#before2
+config typee section5 #after
+
+#be\fo're
+config typef section6 #af\te'r
+
+config typeg section7

--- a/tests/shunit2/references/import_merge.data
+++ b/tests/shunit2/references/import_merge.data
@@ -1,0 +1,10 @@
+config type 'section1'
+	option 'opt' 'val'
+
+	list 'list_opt' 'val0'
+	list 'list_opt' 'val1'
+
+config type 'section3'
+	option 'opt' 'val4'
+	list 'list_opt' 'val5'
+	list 'list_opt' 'val6'

--- a/tests/shunit2/references/import_merge.result
+++ b/tests/shunit2/references/import_merge.result
@@ -1,0 +1,17 @@
+
+config type 'section1'
+	option opt 'val'
+	list list_opt 'val0'
+	list list_opt 'val1'
+
+config type 'section3'
+	option opt 'val7'
+	list list_opt 'val5'
+	list list_opt 'val6'
+	option opt2 'val8'
+
+config type 'section2'
+	option opt 'val4'
+	list list_opt 'val5'
+	list list_opt 'val6'
+

--- a/tests/shunit2/references/import_merge_import.data
+++ b/tests/shunit2/references/import_merge_import.data
@@ -1,0 +1,11 @@
+package 'import-test'
+
+config type 'section2'
+	option 'opt' 'val4'
+	list 'list_opt' 'val5'
+	list 'list_opt' 'val6'
+
+config type 'section3'
+	option 'opt' 'val7'
+	option 'opt2' 'val8'
+

--- a/tests/shunit2/references/import_merge_keep_comments.data
+++ b/tests/shunit2/references/import_merge_keep_comments.data
@@ -1,0 +1,34 @@
+# before config type 'section'
+
+config type 'section'                # after config type 'section'
+	# before option 'opt'
+	option 'opt' 'val' # after option 'opt'
+# before list 'list_opt' 'val0' line 1
+
+	# before list 'list_opt' 'val0' line 2
+	list 'list_opt' 'val0' # after list 'list_opt' 'val0'
+	list 'list_opt' 'val1'
+	option mul_line_opt_sq \''line 1
+line 2 \
+line 3'\' # comment after mul_line_opt_sq
+	option mul_line_opt_dq "\"Hello, \
+World.\'
+" # comment after mul_line_opt_dq
+
+config type 'section3'                # after config type 'section'
+	# before option 'opt'
+	option 'opt' 'val4' # after option 'opt'
+# before list 'list_opt' 'val5' line 1
+
+	# before list 'list_opt' 'val5' line 2
+	list 'list_opt' 'val5' # after list 'list_opt' 'val5'
+	list 'list_opt' 'val6'
+        # comment before mul_line_opt_sq
+	option mul_line_opt_sq \''line 1
+line 2a \
+line 3a'\' # comment after mul_line_opt_sq 2
+	option mul_line_opt_dq "\"Hello, \
+World2.\'
+" # comment after mul_line_opt_dq 2
+
+# this original comment at the end of the file should not be kept

--- a/tests/shunit2/references/import_merge_keep_comments.result
+++ b/tests/shunit2/references/import_merge_keep_comments.result
@@ -1,0 +1,34 @@
+
+# before config type 'section'
+config type 'section' # after config type 'section'
+	# before option 'opt'
+	option opt 'val' # after option 'opt'
+	# before list 'list_opt' 'val0' line 1
+	# before list 'list_opt' 'val0' line 2
+	list list_opt 'val0' # after list 'list_opt' 'val0'
+	list list_opt 'val1'
+	option mul_line_opt_sq ''\''line 1
+line 2 \
+line 3'\''' # comment after mul_line_opt_sq
+	option mul_line_opt_dq '"Hello, World.'\''
+' # comment after mul_line_opt_dq
+
+config type 'section3'
+	option opt 'val7'
+	# before list 'list_opt' 'val5' line 1
+	# before list 'list_opt' 'val5' line 2
+	list list_opt 'val5' # after list 'list_opt' 'val5'
+	list list_opt 'val6'
+	# comment before mul_line_opt_sq
+	option mul_line_opt_sq ''\''line 1
+line 2a \
+line 3a'\''' # comment after mul_line_opt_sq 2
+	option mul_line_opt_dq '"Hello, World2.'\''
+' # comment after mul_line_opt_dq 2
+	option opt2 'val8'
+
+config type 'section2'
+	option opt 'val4'
+	list list_opt 'val5'
+	list list_opt 'val6'
+

--- a/tests/shunit2/references/import_merge_keep_comments_import.data
+++ b/tests/shunit2/references/import_merge_keep_comments_import.data
@@ -1,0 +1,11 @@
+package 'import-test'
+
+config type 'section2'
+	option 'opt' 'val4'
+	list 'list_opt' 'val5'
+	list 'list_opt' 'val6'
+
+config type 'section3'
+	option 'opt' 'val7'
+	option 'opt2' 'val8'
+

--- a/tests/shunit2/references/import_merge_with_comments.data
+++ b/tests/shunit2/references/import_merge_with_comments.data
@@ -1,0 +1,20 @@
+package 'import-test'
+
+# 2before config type 'section'
+config type 'section' # 2after config type 'section'
+	# before option 'opt'
+	option opt 'optval' # after option 'opt'
+	# before
+	list list_opt 'val7' # after
+	list list_opt 'differentval'
+	option mul_line_opt_sq ''\''line 1
+line 2 \
+line 3'\''' # comment after mul_line_opt_sq
+	option mul_line_opt_dq '"Hello, World.'\''
+' # 2comment after mul_line_opt_dq
+	option newopt 'newval'
+
+# 1somecomment before
+config type 'section2' # 1somecomment after
+	# 2somecomment before
+	option opt2 'val2' # 2somecomment after

--- a/tests/shunit2/references/import_merge_with_comments.result1
+++ b/tests/shunit2/references/import_merge_with_comments.result1
@@ -1,0 +1,19 @@
+
+# before config type 'section'
+config type 'section' # after config type 'section'
+	# before option 'opt'
+	option opt 'val' # after option 'opt'
+	# before list 'list_opt' 'val0' line 1
+	# before list 'list_opt' 'val0' line 2
+	list list_opt 'val0' # after list 'list_opt' 'val0'
+	list list_opt 'val1'
+	# before list 'list_opt' 'val0' line 1
+	# before list 'list_opt' 'val0' line 2
+	list list_opt 'val0' # after list 'list_opt' 'val0'
+	list list_opt 'val1'
+	option mul_line_opt_sq ''\''line 1
+line 2 \
+line 3'\''' # comment after mul_line_opt_sq
+	option mul_line_opt_dq '"Hello, World.'\''
+' # comment after mul_line_opt_dq
+

--- a/tests/shunit2/references/import_merge_with_comments.result2
+++ b/tests/shunit2/references/import_merge_with_comments.result2
@@ -1,0 +1,28 @@
+
+# 2before config type 'section'
+config type 'section' # 2after config type 'section'
+	# before option 'opt'
+	option opt 'optval' # after option 'opt'
+	# before list 'list_opt' 'val0' line 1
+	# before list 'list_opt' 'val0' line 2
+	list list_opt 'val0' # after list 'list_opt' 'val0'
+	list list_opt 'val1'
+	# before list 'list_opt' 'val0' line 1
+	# before list 'list_opt' 'val0' line 2
+	list list_opt 'val0' # after list 'list_opt' 'val0'
+	list list_opt 'val1'
+	# before
+	list list_opt 'val7' # after
+	list list_opt 'differentval'
+	option mul_line_opt_sq ''\''line 1
+line 2 \
+line 3'\''' # comment after mul_line_opt_sq
+	option mul_line_opt_dq '"Hello, World.'\''
+' # 2comment after mul_line_opt_dq
+	option newopt 'newval'
+
+# 1somecomment before
+config type 'section2' # 1somecomment after
+	# 2somecomment before
+	option opt2 'val2' # 2somecomment after
+

--- a/tests/shunit2/references/import_with_comments.data
+++ b/tests/shunit2/references/import_with_comments.data
@@ -1,0 +1,20 @@
+# before package 'import-test' line 1
+# before package 'import-test' line 2
+package 'import-test' # after package 'import-test'
+
+# before config type 'section'
+
+config type 'section'                # after config type 'section'
+	# before option 'opt'
+	option 'opt' 'val' # after option 'opt'
+# before list 'list_opt' 'val0' line 1
+
+	# before list 'list_opt' 'val0' line 2
+	list 'list_opt' 'val0' # after list 'list_opt' 'val0'
+	list 'list_opt' 'val1'
+	option mul_line_opt_sq \''line 1
+line 2 \
+line 3'\' # comment after mul_line_opt_sq
+	option mul_line_opt_dq "\"Hello, \
+World.\'
+" # comment after mul_line_opt_dq

--- a/tests/shunit2/references/import_with_comments.result
+++ b/tests/shunit2/references/import_with_comments.result
@@ -1,0 +1,15 @@
+
+# before config type 'section'
+config type 'section' # after config type 'section'
+	# before option 'opt'
+	option opt 'val' # after option 'opt'
+	# before list 'list_opt' 'val0' line 1
+	# before list 'list_opt' 'val0' line 2
+	list list_opt 'val0' # after list 'list_opt' 'val0'
+	list list_opt 'val1'
+	option mul_line_opt_sq ''\''line 1
+line 2 \
+line 3'\''' # comment after mul_line_opt_sq
+	option mul_line_opt_dq '"Hello, World.'\''
+' # comment after mul_line_opt_dq
+

--- a/tests/shunit2/references/set_existing_option_keep_comments.data
+++ b/tests/shunit2/references/set_existing_option_keep_comments.data
@@ -1,0 +1,25 @@
+# section comment
+config 'named' 'section' # section comment 2
+	# comment before existingopt
+	option existingopt 'val' # comment after existingopt
+
+	# opt oldcomment before
+	option opt 'oldval' # opt oldcomment after
+
+	# opt2 oldcomment before
+	option opt2 'oldval2' # opt2 oldcomment after
+
+	# opt3 oldcomment before
+	option opt3 'oldval3' # opt3 oldcomment after
+
+	# opt4 oldcomment before
+	option opt4 'oldval4' # opt4 oldcomment after
+
+	# opt5 oldcomment before
+	option opt5 'oldval5' # opt5 oldcomment after
+
+	# opt6 oldcomment before
+	option opt6 'oldval6' # opt6 oldcomment after
+
+	# opt7 oldcomment before
+	option opt7 'oldval7' # opt7 oldcomment after

--- a/tests/shunit2/references/set_existing_option_keep_comments.result
+++ b/tests/shunit2/references/set_existing_option_keep_comments.result
@@ -1,0 +1,21 @@
+
+# section comment
+config named 'section' # section comment 2
+	# comment before existingopt
+	option existingopt 'val' # comment after existingopt
+	option opt 'val'
+	#before1
+	option opt2 'val'
+	#before1
+	#before2
+	option opt3 'val'
+	option opt4 'val' #after
+	#before1
+	option opt5 'val' #after
+	#before1
+	#before2
+	option opt6 'val' #after
+	#be\fore1
+	#be\fore2
+	option opt7 'val' #af\ter
+

--- a/tests/shunit2/references/set_existing_option_multiline_keep_comments.data
+++ b/tests/shunit2/references/set_existing_option_multiline_keep_comments.data
@@ -1,0 +1,65 @@
+config type 'section'
+	#before1
+	option opt1 'val1'
+
+	#before1
+	#before2
+	option opt2 'val2'
+
+	option opt3 'val3' #after
+
+	#before1
+	option opt4 'val4' #after
+
+	#before1
+
+	#before2
+	option opt5 'val5' #after
+
+	#be\fo're
+	option opt6 'val6' #af\te'r
+
+	option opt7 'val7'
+
+	#before1
+	list listopt 'vala'
+
+	#before1
+	#before2
+	list listopt 'valb'
+
+	list listopt 'valc' #after
+
+	#before1
+	list listopt 'vald' #after
+
+	#before1
+
+	#before2
+	list listopt 'valc' #after
+
+	#be\fo're
+	list listopt 'valf' #af\te'r
+
+	list listopt 'vala'
+
+#before1
+config type 'section2'
+
+#before1
+#before2
+config type 'section3'
+
+config type 'section4' #after
+
+#before1
+config type 'section5' #after
+
+#before1
+#before2
+config type 'section6' #after
+
+#be\fore1
+#be\fore2
+config type 'section7' #af\ter
+

--- a/tests/shunit2/references/set_existing_option_multiline_keep_comments.result
+++ b/tests/shunit2/references/set_existing_option_multiline_keep_comments.result
@@ -1,0 +1,52 @@
+
+config type 'section'
+	#before1
+	option opt1 'val1'
+	#beforea
+	#beforeb
+	option opt2 'Hello,\'\''
+World"' #afterc
+	option opt3 'val3' #after
+	#before1
+	option opt4 'val4' #after
+	#before1
+	#before2
+	option opt5 'val5' #after
+	#be\fo're
+	option opt6 'val6' #af\te'r
+	option opt7 'val7'
+	#before1
+	list listopt 'vala'
+	#before1
+	#before2
+	list listopt 'valb'
+	list listopt 'valc' #after
+	#before1
+	list listopt 'vald' #after
+	#before1
+	#before2
+	list listopt 'valc' #after
+	#be\fo're
+	list listopt 'valf' #af\te'r
+	list listopt 'vala'
+
+#before1
+config type 'section2'
+
+#before1
+#before2
+config type 'section3'
+
+config type 'section4' #after
+
+#before1
+config type 'section5' #after
+
+#before1
+#before2
+config type 'section6' #after
+
+#be\fore1
+#be\fore2
+config type 'section7' #af\ter
+

--- a/tests/shunit2/references/set_keep_comments.data
+++ b/tests/shunit2/references/set_keep_comments.data
@@ -1,0 +1,23 @@
+# before
+config named 'section'
+	# before
+	option opt 'val'
+
+	option opt2 'val2' # after1
+
+	#before1
+	#before2
+	option opt3 'val3' # after2
+
+config named 'section2' # after3
+
+#before3
+#before4
+config named 'section3' # after4
+
+#before5
+#before6
+config named 'section4' # after5
+	#before7
+	#before8
+	option opt3 'val3' # after6

--- a/tests/shunit2/references/set_keep_comments.result
+++ b/tests/shunit2/references/set_keep_comments.result
@@ -1,0 +1,17 @@
+
+config named 'section'
+	option opt 'val'
+	option opt2 'val'
+	option opt3 'val'
+
+config named 'section2'
+
+config named 'section3'
+
+#before5
+#before6
+config named 'section4' # after5
+	#before7
+	#before8
+	option opt3 'val3' # after6
+

--- a/tests/shunit2/references/set_named_section_keep_comments.changes
+++ b/tests/shunit2/references/set_named_section_keep_comments.changes
@@ -1,0 +1,7 @@
+set.section='named'
+set.section2='named'##before1\n
+set.section3='named'##before1\n#before2\n
+set.section4='named'##after
+set.section5='named'##before1\n#after
+set.section6='named'##before1\n#before2\n#after
+set.section7='named'##be\\fore1\n#be\\fore2\n#af\\ter

--- a/tests/shunit2/references/set_named_section_keep_comments.result
+++ b/tests/shunit2/references/set_named_section_keep_comments.result
@@ -1,0 +1,23 @@
+
+config named 'section'
+
+#before1
+config named 'section2'
+
+#before1
+#before2
+config named 'section3'
+
+config named 'section4' #after
+
+#before1
+config named 'section5' #after
+
+#before1
+#before2
+config named 'section6' #after
+
+#be\fore1
+#be\fore2
+config named 'section7' #af\ter
+

--- a/tests/shunit2/references/set_nonexistent_option_keep_comments.changes
+++ b/tests/shunit2/references/set_nonexistent_option_keep_comments.changes
@@ -1,0 +1,7 @@
+set.section.opt='val'
+set.section.opt2='val'##before1\n
+set.section.opt3='val'##before1\n#before2\n
+set.section.opt4='val'##after
+set.section.opt5='val'##before1\n#after
+set.section.opt6='val'##before1\n#before2\n#after
+set.section.opt7='val'##be\\fore1\n#be\\fore2\n#af\\ter

--- a/tests/shunit2/references/set_nonexistent_option_keep_comments.data
+++ b/tests/shunit2/references/set_nonexistent_option_keep_comments.data
@@ -1,0 +1,4 @@
+# section comment
+config 'named' 'section' # section comment 2
+	# comment before existingopt
+	option existingopt 'val' # comment after existingopt

--- a/tests/shunit2/references/set_nonexistent_option_keep_comments.result
+++ b/tests/shunit2/references/set_nonexistent_option_keep_comments.result
@@ -1,0 +1,21 @@
+
+# section comment
+config named 'section' # section comment 2
+	# comment before existingopt
+	option existingopt 'val' # comment after existingopt
+	option opt 'val'
+	#before1
+	option opt2 'val'
+	#before1
+	#before2
+	option opt3 'val'
+	option opt4 'val' #after
+	#before1
+	option opt5 'val' #after
+	#before1
+	#before2
+	option opt6 'val' #after
+	#be\fore1
+	#be\fore2
+	option opt7 'val' #af\ter
+

--- a/tests/shunit2/references/set_nonexistent_option_multiline_keep_comments.data
+++ b/tests/shunit2/references/set_nonexistent_option_multiline_keep_comments.data
@@ -1,0 +1,65 @@
+config type 'section'
+	#before1
+	option opt1 'val1'
+
+	#before1
+	#before2
+	option opt2 'val2'
+
+	option opt3 'val3' #after
+
+	#before1
+	option opt4 'val4' #after
+
+	#before1
+
+	#before2
+	option opt5 'val5' #after
+
+	#be\fo're
+	option opt6 'val6' #af\te'r
+
+	option opt7 'val7'
+
+	#before1
+	list listopt 'vala'
+
+	#before1
+	#before2
+	list listopt 'valb'
+
+	list listopt 'valc' #after
+
+	#before1
+	list listopt 'vald' #after
+
+	#before1
+
+	#before2
+	list listopt 'valc' #after
+
+	#be\fo're
+	list listopt 'valf' #af\te'r
+
+	list listopt 'vala'
+
+#before1
+config type 'section2'
+
+#before1
+#before2
+config type 'section3'
+
+config type 'section4' #after
+
+#before1
+config type 'section5' #after
+
+#before1
+#before2
+config type 'section6' #after
+
+#be\fore1
+#be\fore2
+config type 'section7' #af\ter
+

--- a/tests/shunit2/references/set_nonexistent_option_multiline_keep_comments.result
+++ b/tests/shunit2/references/set_nonexistent_option_multiline_keep_comments.result
@@ -1,0 +1,55 @@
+
+config type 'section'
+	#before1
+	option opt1 'val1'
+	#before1
+	#before2
+	option opt2 'val2'
+	option opt3 'val3' #after
+	#before1
+	option opt4 'val4' #after
+	#before1
+	#before2
+	option opt5 'val5' #after
+	#be\fo're
+	option opt6 'val6' #af\te'r
+	option opt7 'val7'
+	#before1
+	list listopt 'vala'
+	#before1
+	#before2
+	list listopt 'valb'
+	list listopt 'valc' #after
+	#before1
+	list listopt 'vald' #after
+	#before1
+	#before2
+	list listopt 'valc' #after
+	#be\fo're
+	list listopt 'valf' #af\te'r
+	list listopt 'vala'
+	#beforea
+	#beforeb
+	option opt8 'Hello,\'\''
+World"' #afterc
+
+#before1
+config type 'section2'
+
+#before1
+#before2
+config type 'section3'
+
+config type 'section4' #after
+
+#before1
+config type 'section5' #after
+
+#before1
+#before2
+config type 'section6' #after
+
+#be\fore1
+#be\fore2
+config type 'section7' #af\ter
+

--- a/tests/shunit2/references/show_parsing_multiline.data
+++ b/tests/shunit2/references/show_parsing_multiline.data
@@ -1,11 +1,15 @@
 config main
         option version  1.4.1
 
+# sockd configuration for vpn and wan
 config sockd 'instance0'
         option enabled  1
+	# sockd for vpn
         list internal_network   vpn
+	# ... and for wan
         list external_network   wan
 
+	# a long multi-line option
         option extra_config '
 		user.unprivileged: nobody
 		client pass {
@@ -17,4 +21,4 @@ config sockd 'instance0'
 		socks pass {
 			from: 0.0.0.0/0 to: 0.0.0.0/0
 			log: connect
-		} '
+		} ' # the long multi-line option ends here

--- a/tests/shunit2/tests.d/000_import
+++ b/tests/shunit2/tests.d/000_import
@@ -1,5 +1,62 @@
 test_import ()
 {
 	${UCI} import < ${REF_DIR}/import.data
+	assertTrue $?
 	assertSameFile ${REF_DIR}/import.result ${CONFIG_DIR}/import-test
+}
+
+make_abspath()
+{
+	# this should work with /bin/sh
+	echo "$(cd -- "$(dirname "$1")"; pwd)/$(basename "$1")"
+}
+
+test_import_merge ()
+{
+	cp "${REF_DIR}/import_merge.data" "${CONFIG_DIR}/import-test"
+        # if the full path of the config file is specified, 'import' applies
+        # the changes immediately without requiring a commit.
+	ABSPATH="$(make_abspath "${CONFIG_DIR}/import-test")"
+	${UCI} -m import "${ABSPATH}" < "${REF_DIR}/import_merge_import.data"
+	assertTrue $?
+	assertSameFile "${REF_DIR}/import_merge.result" "${CONFIG_DIR}/import-test"
+}
+
+test_import_merge_keep_comments ()
+{
+	cp "${REF_DIR}/import_merge_keep_comments.data" "${CONFIG_DIR}/import-test"
+        # if the full path of the config file is specified, 'import' applies
+        # the changes immediately without requiring a commit.
+	ABSPATH="$(make_abspath "${CONFIG_DIR}/import-test")"
+	${UCI} -m import "${ABSPATH}" < "${REF_DIR}/import_merge_keep_comments_import.data"
+	assertTrue $?
+	assertSameFile "${REF_DIR}/import_merge_keep_comments.result" "${CONFIG_DIR}/import-test"
+}
+
+test_import_with_comments ()
+{
+	${UCI} import < "${REF_DIR}/import_with_comments.data"
+	assertTrue $?
+	assertSameFile "${REF_DIR}/import_with_comments.result" "${CONFIG_DIR}/import-test"
+}
+
+test_import_merge_with_comments ()
+{
+	${UCI} import < "${REF_DIR}/import_with_comments.data"
+	assertTrue $?
+	assertSameFile ${REF_DIR}/import_with_comments.result ${CONFIG_DIR}/import-test
+
+	# merge the same data again: list entries should be appended again
+	${UCI} -m import import-test < "${REF_DIR}/import_with_comments.data"
+	assertTrue $?
+	${UCI} commit
+	assertTrue $?
+	assertSameFile "${REF_DIR}/import_merge_with_comments.result1" "${CONFIG_DIR}/import-test"
+
+	# merge different data
+	${UCI} -m import import-test < "${REF_DIR}/import_merge_with_comments.data"
+	assertTrue $?
+	${UCI} commit
+	assertTrue $?
+	assertSameFile "${REF_DIR}/import_merge_with_comments.result2" "${CONFIG_DIR}/import-test"
 }

--- a/tests/shunit2/tests.d/010_export
+++ b/tests/shunit2/tests.d/010_export
@@ -12,3 +12,18 @@ test_export ()
 	assertTrue $?
 	assertSameFile ${REF_DIR}/export.result ${TMP_DIR}/export.result
 }
+
+test_export_keep_comments ()
+{
+	cp ${REF_DIR}/export_keep_comments.data ${CONFIG_DIR}/export
+
+	${UCI_Q} export nilpackage
+	assertFalse $?
+
+	${UCI_Q} export export 1>/dev/null 2>&1
+	assertTrue $?
+
+	${UCI} export > ${TMP_DIR}/export_keep_comments.result
+	assertTrue $?
+	assertSameFile ${REF_DIR}/export_keep_comments.result ${TMP_DIR}/export_keep_comments.result
+}

--- a/tests/shunit2/tests.d/020_get
+++ b/tests/shunit2/tests.d/020_get
@@ -10,6 +10,24 @@ test_get_parsing()
 	assertFailWithNoReturn "${UCI_Q} get test.section.opt.valqsqsd"
 }
 
+test_get_parsing_keep_comments()
+{
+	cp ${REF_DIR}/get_parsing_keep_comments.data ${CONFIG_DIR}/test
+
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.section.'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.section.opt.'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.section.opt.val.'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.section.opt.val.qsdf.qsd'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.section.opt.valqsqsd'
+
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.section.opt' '## '
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.section.opt=val' '##'
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.section.opt=val' '## '
+
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.section' '##'
+}
+
 test_get_section_index_parsing()
 {
 	cp ${REF_DIR}/get_parsing.data ${CONFIG_DIR}/test
@@ -24,11 +42,132 @@ test_get_section_index_parsing()
 	assertFailWithNoReturn "${UCI_Q} get test.@[1].val."
 }
 
+test_get_section_index_parsing_keep_comments()
+{
+	cp ${REF_DIR}/get_parsing.data ${CONFIG_DIR}/test
+
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@zer.'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@.'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@zer[1]'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@.opt'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@[28]'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@[1].'
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@[1].val.'
+
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.@[1]' '## '
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.@[1].opt' '## '
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.@[1].opt=val' '##'
+	assertFailWithNoReturn2DiscardStderr ${UCI_Q} get 'test.@[1].opt=val' '## '
+
+	assertFailWithNoReturn2 ${UCI_Q} get 'test.@[1]' '##'
+}
+
+test_get_section_keep_comments()
+{
+	cp ${REF_DIR}/get_section_keep_comments.data ${CONFIG_DIR}/test
+
+	type="$(${UCI} get test.section1)"
+	assertEquals "typea" "$type"
+	comment="$(${UCI} get 'test.section1' '#')"
+	assertEquals "$(echo "'#before1\n'")" "$comment"
+
+	type="$(${UCI} get test.section2)"
+	assertEquals "typeb" "$type"
+	comment="$(${UCI} get 'test.section2' '#')"
+	assertEquals "$(echo "'#before1\n#before2\n'")" "$comment"
+
+	type="$(${UCI} get test.section3)"
+	assertEquals "typec" "$type"
+	comment="$(${UCI} get 'test.section3' '#')"
+	assertEquals "'#after'" "$comment"
+
+	type="$(${UCI} get test.section4)"
+	assertEquals "typed" "$type"
+	comment="$(${UCI} get 'test.section4' '#')"
+	assertEquals "$(echo "'#before1\n#after'")" "$comment"
+
+	type="$(${UCI} get test.section5)"
+	assertEquals "typee" "$type"
+	comment="$(${UCI} get 'test.section5' '#')"
+	assertEquals "$(echo "'#before1\n#before2\n#after'")" "$comment"
+
+	type="$(${UCI} get test.section6)"
+	assertEquals "typef" "$type"
+	# uci should print:
+	# '#be\fo'\''re
+	# af\te'\''r'
+	comment="$(${UCI} get 'test.section6' '#')"
+	assertEquals "$(echo "'#be\\\\fo'\\\\''re\n#af\\\\te'\\\\''r'")" "$comment"
+
+	type="$(${UCI} get test.section7)"
+	assertEquals "typeg" "$type"
+	comment="$(${UCI} get 'test.section7' '#')"
+	assertEquals "''" "$comment"
+}
+
 test_get_option()
 {
 	cp ${REF_DIR}/get.data ${CONFIG_DIR}/test
 	value=$($UCI get test.section.opt)
 	assertEquals 'val' "$value"
+}
+
+test_get_option_keep_comments()
+{
+	cp ${REF_DIR}/get_option_keep_comments.data ${CONFIG_DIR}/test
+
+	value="$($UCI get 'test.section.opt1')"
+	assertEquals "val1" "$value"
+	comment="$($UCI get 'test.section.opt1' '#')"
+	assertEquals "$(echo "'#before1\n'")" "$comment"
+
+	value="$($UCI get 'test.section.opt2')"
+	assertEquals "val2" "$value"
+	comment="$($UCI get 'test.section.opt2' '#')"
+	assertEquals "$(echo "'#before1\n#before2\n'")" "$comment"
+
+	value="$($UCI get 'test.section.opt3')"
+	assertEquals "val3" "$value"
+	comment="$($UCI get 'test.section.opt3' '#')"
+	assertEquals "'#after'" "$comment"
+
+	value="$($UCI get 'test.section.opt4')"
+	assertEquals "val4" "$value"
+	comment="$($UCI get 'test.section.opt4' '#')"
+	assertEquals "$(echo "'#before1\n#after'")" "$comment"
+
+	value="$($UCI get 'test.section.opt5')"
+	assertEquals "val5" "$value"
+	comment="$($UCI get 'test.section.opt5' '#')"
+	assertEquals "$(echo "'#before1\n#before2\n#after'")" "$comment"
+
+	value="$($UCI get 'test.section.opt6')"
+	assertEquals "val6" "$value"
+	# uci should print:
+	# '#be\fo'\''re
+	# af\te'\''r'
+	comment="$($UCI get 'test.section.opt6' '#')"
+	assertEquals "$(echo "'#be\\\\fo'\\\\''re\n#af\\\\te'\\\\''r'")" "$comment"
+
+	value="$($UCI get 'test.section.opt7')"
+	assertEquals "val7" "$value"
+	comment="$($UCI get 'test.section.opt7' '#')"
+	assertEquals "''" "$comment"
+
+	value="$($UCI get 'test.section.listopt')"
+	assertEquals "vala valb valc vald valc valf vala" "$value"
+	# uci should print:
+	# '#before1
+	# ' '#before1
+	# #before2
+	# ' '#after' '#before1
+	# #after' '#before1
+	# #before2
+	# #after' '#be\fo'\''re
+	# af\te'\''r' ''
+	comment="$($UCI get 'test.section.listopt' '#')"
+	assertEquals "$(echo "'#before1\n' '#before1\n#before2\n' '#after' '#before1\n#after' '#before1\n#before2\n#after' '#be\\\\fo'\\\\''re\n#af\\\\te'\\\\''r' ''")" "$comment"
 }
 
 test_get_option_multiline()
@@ -37,6 +176,16 @@ test_get_option_multiline()
 	value="$($UCI get test.section.opt)"
 	assertEquals '"Hello, World.
 '\''' "$value"
+}
+
+test_get_option_multiline_keep_comments()
+{
+	cp "${REF_DIR}/get_option_multiline_keep_comments.data" "${CONFIG_DIR}/test"
+	value="$($UCI get test.section.opt)"
+	assertEquals '"Hello, World.
+  '\''' "$value"
+	comment="$($UCI get 'test.section.opt' '#')"
+	assertEquals "$(echo "'# Can preserve trailing whitespace with assertEquals.\n### comment4'")" "$comment"
 }
 
 test_get_section()

--- a/tests/shunit2/tests.d/030_set
+++ b/tests/shunit2/tests.d/030_set
@@ -8,6 +8,41 @@ test_set_parsing()
 	assertFailWithNoReturn "${UCI_Q} set test.section.opt.zflk=val"
 }
 
+tests_set_parsing_keep_comments()
+{
+	# NB: $(command) removes all newlines at the end of the output of command
+	# so we can only use echo (or printf) for newlines not at the end
+
+	cp ${REF_DIR}/set_parsing.data ${CONFIG_DIR}/test
+
+	assertFailWithNoReturn2 ${UCI_Q} set 'test.=val'
+	assertFailWithNoReturn2 ${UCI_Q} set 'test.section.=val'
+	assertFailWithNoReturn2 ${UCI_Q} set 'test.section.opt.=val'
+	assertFailWithNoReturn2 ${UCI_Q} set 'test.section.opt.zflk=val'
+
+	# missing '#'
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" ""
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" " "
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "a"
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "
+"
+	# missing '#' immediately after first newline for comment line before option
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "#
+
+"
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "$(echo "#\n #")
+"
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "$(echo "#\na#")
+"
+
+	# missing '#' immediately after second newline for comment after option
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "$(echo "#\n#\n ")"
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "$(echo "#\n#\na")"
+	assertFailWithNoReturn2 ${UCI_Q} set "test.section.opt=val" "$(echo "#\n#")
+
+"
+}
+
 test_set_named_section()
 {
 	touch ${CONFIG_DIR}/set
@@ -15,11 +50,55 @@ test_set_named_section()
 	assertSameFile ${REF_DIR}/set_named_section.result ${CHANGES_DIR}/set
 }
 
+tests_set_named_section_keep_comments()
+{
+	# NB: $(command) removes all newlines at the end of the output of command
+	# so we can only use echo (or printf) for newlines not at the end
+
+	>"${CONFIG_DIR}/set"
+	${UCI} set 'set.section=named'
+	${UCI} set "set.section2=named" "#before1
+"
+	${UCI} set "set.section3=named" "$(echo "#before1\n#before2")
+"
+	${UCI} set "set.section4=named" "#after"
+	${UCI} set "set.section5=named" "$(echo "#before1\n#after")"
+	${UCI} set "set.section6=named" "$(echo "#before1\n#before2\n#after")"
+	${UCI} set "set.section7=named" "$(echo "#be\\\\fore1\n#be\\\\fore2\n#af\\\\ter")"
+	assertSameFile "${REF_DIR}/set_named_section_keep_comments.changes" "${CHANGES_DIR}/set"
+	${UCI} commit
+	assertSameFile "${REF_DIR}/set_named_section_keep_comments.result" "${CONFIG_DIR}/set"
+}
+
+test_set_option_in_nonexistent_section()
+{
+	>${CONFIG_DIR}/set
+	# section does not exist
+	assertFailWithNoReturn2 ${UCI_Q} set test.nonexistentsection.opt=val
+}
+
 test_set_nonexisting_option()
 {
 	cp ${REF_DIR}/set_nonexisting_option.data ${CONFIG_DIR}/set
 	${UCI} set set.section.opt=val
 	assertSameFile ${REF_DIR}/set_nonexisting_option.result ${CHANGES_DIR}/set
+}
+
+test_set_nonexistent_option_keep_comments()
+{
+	cp ${REF_DIR}/set_nonexistent_option_keep_comments.data ${CONFIG_DIR}/set
+	${UCI} set 'set.section.opt=val'
+	${UCI} set "set.section.opt2=val" "$(echo "#before1")
+"
+	${UCI} set "set.section.opt3=val" "$(echo "#before1\n#before2")
+"
+	${UCI} set "set.section.opt4=val" "$(echo "#after")"
+	${UCI} set "set.section.opt5=val" "$(echo "#before1\n#after")"
+	${UCI} set "set.section.opt6=val" "$(echo "#before1\n#before2\n#after")"
+	${UCI} set "set.section.opt7=val" "$(echo "#be\\\\fore1\n#be\\\\fore2\n#af\\\\ter")"
+	assertSameFile "${REF_DIR}/set_nonexistent_option_keep_comments.changes" "${CHANGES_DIR}/set"
+	${UCI} commit
+	assertSameFile "${REF_DIR}/set_nonexistent_option_keep_comments.result" "${CONFIG_DIR}/set"
 }
 
 test_set_nonexisting_option_multiline()
@@ -30,11 +109,61 @@ World\""
 	assertSameFile ${REF_DIR}/set_nonexisting_option_multiline.result ${CHANGES_DIR}/set
 }
 
+test_set_nonexistent_option_multiline_keep_comments()
+{
+	cp "${REF_DIR}/set_nonexistent_option_multiline_keep_comments.data" "${CONFIG_DIR}/set"
+	${UCI} set set.section.opt8="Hello,\'
+World\"" "$(echo "#beforea\n#beforeb\n#afterc")"
+	${UCI} commit
+	assertSameFile "${REF_DIR}/set_nonexistent_option_multiline_keep_comments.result" "${CONFIG_DIR}/set"
+}
+
 test_set_existing_option()
 {
 	cp ${REF_DIR}/set_existing_option.data ${CONFIG_DIR}/set
 	${UCI} set set.section.opt=val
 	assertSameFile ${REF_DIR}/set_existing_option.result ${CHANGES_DIR}/set
+}
+
+test_set_existing_option_keep_comments()
+{
+	cp "${REF_DIR}/set_existing_option_keep_comments.data" "${CONFIG_DIR}/set"
+	${UCI} set set.section.opt=val
+	${UCI} set "set.section.opt2=val" "#before1
+"
+	${UCI} set "set.section.opt3=val" "$(echo "#before1\n#before2")
+"
+	${UCI} set "set.section.opt4=val" "#after"
+	${UCI} set "set.section.opt5=val" "$(echo "#before1\n#after")"
+	${UCI} set "set.section.opt6=val" "$(echo "#before1\n#before2\n#after")"
+	${UCI} set "set.section.opt7=val" "$(echo "#be\\\\fore1\n#be\\\\fore2\n#af\\\\ter")"
+	${UCI} commit
+	assertSameFile "${REF_DIR}/set_existing_option_keep_comments.result" "${CONFIG_DIR}/set"
+}
+
+test_set_keep_comments()
+{
+	cp ${REF_DIR}/set_keep_comments.data ${CONFIG_DIR}/set
+
+	# Test that a set command without comments removes the original comments
+	# associated with the entry
+
+	# original section has comment lines before
+	${UCI} set set.section=named
+	# original section has comment after
+	${UCI} set set.section2=named
+	# original section has comment lines before and comment after
+	${UCI} set set.section3=named
+
+	# original option has comment lines before
+	${UCI} set set.section.opt=val
+	# original option has comment after
+	${UCI} set set.section.opt2=val
+	# original option has comment lines before and comment after
+	${UCI} set set.section.opt3=val
+
+	${UCI} commit
+	assertSameFile ${REF_DIR}/set_keep_comments.result ${CONFIG_DIR}/set
 }
 
 test_set_existing_option_multiline()
@@ -43,4 +172,13 @@ test_set_existing_option_multiline()
 	${UCI} set set.section.opt="Hello,\'
 World\""
 	assertSameFile ${REF_DIR}/set_existing_option_multiline.result ${CHANGES_DIR}/set
+}
+
+test_set_existing_option_multiline_keep_comments()
+{
+	cp "${REF_DIR}/set_existing_option_multiline_keep_comments.data" "${CONFIG_DIR}/set"
+	${UCI} set set.section.opt2="Hello,\'
+World\"" "$(echo "#beforea\n#beforeb\n#afterc")"
+	${UCI} commit
+	assertSameFile "${REF_DIR}/set_existing_option_multiline_keep_comments.result" "${CONFIG_DIR}/set"
 }

--- a/tests/shunit2/tests.d/050_show
+++ b/tests/shunit2/tests.d/050_show
@@ -1,45 +1,69 @@
-test_get_parsing()
+static_test_get_parsing()
 {
 	cp ${REF_DIR}/show_parsing.data ${CONFIG_DIR}/test
 
-	assertFailWithNoReturn "${UCI_Q} show test."
-	assertFailWithNoReturn "${UCI_Q} show test.section."
-	assertFailWithNoReturn "${UCI_Q} show test.section.opt."
-	assertFailWithNoReturn "${UCI_Q} show test.section.opt.val."
-	assertFailWithNoReturn "${UCI_Q} show test.section.opt.val.qsdf.qsd"
-	assertFailWithNoReturn "${UCI_Q} show test.section.opt.valqsqsd"
-	assertFailWithNoReturn "${UCI_Q} show test.nilsection"
-	assertFailWithNoReturn "${UCI_Q} show test.nilsection.nilopt"
-	assertFailWithNoReturn "${UCI_Q} show test.section.nilopt"
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test."
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.section."
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.section.opt."
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.section.opt.val."
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.section.opt.val.qsdf.qsd"
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.section.opt.valqsqsd"
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.nilsection"
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.nilsection.nilopt"
+	assertFailWithNoReturn "${UCI_Q} ${UCI_OPTS} show test.section.nilopt"
 }
 
-prepare_get_parsing_multiline() {
+static_prepare_get_parsing_multiline() {
 	cp ${REF_DIR}/show_parsing_multiline.data ${CONFIG_DIR}/sockd
 }
 
-test_get_parsing_multiline_package()
+static_test_get_parsing_multiline_package()
 {
-	prepare_get_parsing_multiline
+	static_prepare_get_parsing_multiline
 
-	value=$(${UCI_Q} show sockd)
+	value=$(${UCI_Q} ${UCI_OPTS} show sockd)
 	value_ref=$(cat ${REF_DIR}/show_parsing_multiline_package.result)
 	assertEquals "$value_ref" "$value"
 }
 
-test_get_parsing_multiline_section()
+static_test_get_parsing_multiline_section()
 {
-	prepare_get_parsing_multiline
+	static_prepare_get_parsing_multiline
 
-	value=$(${UCI_Q} show sockd.instance0)
+	value=$(${UCI_Q} ${UCI_OPTS} show sockd.instance0)
 	value_ref=$(cat ${REF_DIR}/show_parsing_multiline_section.result)
 	assertEquals "$value_ref" "$value"
 }
 
-test_get_parsing_multiline_option()
+static_test_get_parsing_multiline_option()
 {
-	prepare_get_parsing_multiline
+	static_prepare_get_parsing_multiline
 
-	value=$(${UCI_Q} show sockd.instance0.extra_config)
+	value=$(${UCI_Q} ${UCI_OPTS} show sockd.instance0.extra_config)
 	value_ref=$(cat ${REF_DIR}/show_parsing_multiline_option.result)
 	assertEquals "$value_ref" "$value"
+}
+
+test_get_parsing() {
+	for UCI_OPTS in '' '-D'; do
+		static_test_get_parsing
+	done
+}
+
+test_get_parsing_multiline_package() {
+	for UCI_OPTS in '' '-D'; do
+		static_test_get_parsing_multiline_package
+	done
+}
+
+test_get_parsing_multiline_section() {
+	for UCI_OPTS in '' '-D'; do
+		static_test_get_parsing_multiline_section
+	done
+}
+
+test_get_parsing_multiline_option() {
+	for UCI_OPTS in '' '-D'; do
+		static_test_get_parsing_multiline_option
+	done
 }

--- a/tests/shunit2/tests.d/060_batch
+++ b/tests/shunit2/tests.d/060_batch
@@ -30,7 +30,7 @@ set batch_comments.SEC0.option0='value0'
 
 set batch_comments.SEC0.option1='"Hello,
 '"  World\""
-set batch_comments.SEC1='section'
+set batch_comments.SEC1='section' # comment at end of line
 set batch_comments.SEC1.option0="value1"
 
  	 # comment line starts with spaces.
@@ -40,4 +40,28 @@ commit
 EOF
 
 	assertSameFile "${REF_DIR}/batch_comments.result" "${CONFIG_DIR}/batch_comments"
+}
+
+test_batch_keep_comments()
+{
+	>"${CONFIG_DIR}/batch_keep_comments"
+
+	OUTFILE="${TMP_DIR}/batch_keep_comments.output"
+
+        ${UCI} batch >"$OUTFILE" <<EOF
+set batch_keep_comments.SEC0='section' '# comment after section'
+set batch_keep_comments.SEC0.interface='home' '# comment before interface
+# comment after interface'
+add_list batch_keep_comments.SEC0.listopt='listitem' "# comment before listopt
+"
+commit
+get batch_keep_comments.SEC0.interface
+get batch_keep_comments.SEC0.interface #
+get 'batch_keep_comments.SEC0.interface' '#'
+get "batch_keep_comments.SEC0.interface" "#"
+EOF
+	assertSameFile "${REF_DIR}/batch_keep_comments.result" "${CONFIG_DIR}/batch_keep_comments"
+	assertSameFile "${REF_DIR}/batch_keep_comments_output.result" "$OUTFILE"
+
+	rm -f "$OUTFILE"
 }

--- a/tests/shunit2/tests.d/080_list
+++ b/tests/shunit2/tests.d/080_list
@@ -5,6 +5,49 @@ prepare_list_test() {
 	${UCI} add_list list_test_config.SEC0.list0='"Hello
 ,'" world\""
 }
+
+test_add_list_parsing() {
+	cp ${REF_DIR}/add_list_parsing.data ${CONFIG_DIR}/test
+
+	assertFailWithNoReturn "${UCI_Q} add_list test.=val"
+	assertFailWithNoReturn "${UCI_Q} add_list test.section.=val"
+	assertFailWithNoReturn "${UCI_Q} add_list test.section.opt.=val"
+	assertFailWithNoReturn "${UCI_Q} add_list test.section.opt.zflk=val"
+
+	# missing '#'
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' ''
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' ' '
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' 'a'
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '
+'
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '
+
+'
+
+	# missing '#' immediately after first '\n' for comment line before option
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '#
+
+'
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '#
+ #
+'
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '#
+a#
+'
+
+	# missing '#' immediately after second '\n' for comment after option
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '#
+#
+ '
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '#
+#
+a'
+	assertFailWithNoReturn2 ${UCI_Q} add_list 'test.section.opt=val' '#
+#
+
+'
+}
+
 test_add_list_config() {
 	prepare_list_test
 	${UCI} commit
@@ -34,6 +77,35 @@ test_add_list_changes() {
 	assertEquals "$value_list_changes" "$value_list_changes_ref"
 }
 
+test_add_list_keep_comments() {
+	cp ${REF_DIR}/add_list_keep_comments.data ${CONFIG_DIR}/test
+	assertSuccess ${UCI} add_list 'test.section.listopt=val'
+	assertSuccess ${UCI} add_list 'test.section.listopt=val2'
+	assertSuccess ${UCI} commit
+	assertSameFile ${REF_DIR}/add_list_keep_comments.result ${CONFIG_DIR}/test
+
+	# add_list can't change a list entry, it adds list entries only.
+}
+
+test_add_list_keep_comments2() {
+	echo -n >${CONFIG_DIR}/test
+	assertSuccess ${UCI} set test.section=named
+	assertSuccess ${UCI} commit
+        assertSuccess ${UCI} add_list 'test.section.listopt=val' "#before1
+"
+        assertSuccess ${UCI} add_list 'test.section.listopt=val2' "$(echo "#before1\n#before2")
+"
+        assertSuccess ${UCI} add_list 'test.section.listopt=val3' "#after"
+        assertSuccess ${UCI} add_list 'test.section.listopt=val4' "$(echo "#before1\n#after")"
+        assertSuccess ${UCI} add_list 'test.section.listopt=val5' "$(echo "#before1\n#before2\n#after")"
+        assertSuccess ${UCI} add_list 'test.section.listopt=val6' "$(echo "#be\\\\fore1\n#be\\\\fore2\n#af\\\\ter")"
+	assertSameFile ${REF_DIR}/add_list_keep_comments2.changes ${CHANGES_DIR}/test
+	assertSuccess ${UCI} commit
+	assertSameFile ${REF_DIR}/add_list_keep_comments2.result ${CONFIG_DIR}/test
+
+	# add_list can't change a list entry, it adds list entries only.
+}
+
 test_del_list() {
 	prepare_list_test
 	${UCI} commit
@@ -50,3 +122,18 @@ test_del_list_multiline() {
 	${UCI} commit
 	assertSameFile "${REF_DIR}/del_list_multiline_config.result" "$CONFIG_DIR/list_test_config"
 }
+
+test_del_list_keep_comments() {
+	# list entries with comments
+	cp ${REF_DIR}/del_list_keep_comments.data ${CONFIG_DIR}/test
+	# test that the listopts and their comments are gone with del_list of all entries individually
+	assertSuccess ${UCI} del_list test.section.listopt=val
+	assertSuccess ${UCI} del_list test.section.listopt=val2
+	assertSuccess ${UCI} del_list test.section.listopt=val3
+	assertSuccess ${UCI} del_list test.section.listopt=val4
+	assertSuccess ${UCI} del_list test.section.listopt=val5
+	assertSuccess ${UCI} del_list test.section.listopt=val6
+	${UCI} commit
+	assertSameFile ${REF_DIR}/del_list_keep_comments.result ${CONFIG_DIR}/test
+}
+

--- a/tests/shunit2/tests.d/100_changes
+++ b/tests/shunit2/tests.d/100_changes
@@ -30,3 +30,22 @@ test_changes_missing_value()
 		assertNull "$val"
 	done
 }
+
+test_changes_keep_comments()
+{
+	touch "$CONFIG_DIR/test"
+
+	assertSuccess ${UCI} set 'test.section1=type'
+	assertSuccess ${UCI} set 'test.section1.opt1=val'
+	assertSuccess ${UCI} add_list 'test.section1.listopt1=listval1'
+	assertSuccess ${UCI} add_list 'test.section1.listopt1=listval2'
+
+	assertSuccess ${UCI} set 'test.section2=type' "$(echo "# before section2\n# after section2")"
+	assertSuccess ${UCI} set 'test.section2.opt1=val' "$(echo "# before section2.opt1\n# after section2.opt1")"
+	assertSuccess ${UCI} add_list 'test.section2.listopt1=listval1' "$(echo "# before section2.listopt1")
+"
+	assertSuccess ${UCI} add_list 'test.section2.listopt1=listval2' '# af\ter section2.listopt1'
+
+	assertSuccess ${UCI} changes >"$CONFIG_DIR/test.changes"
+	assertSameFile "${REF_DIR}/changes_keep_comments.result" "${CONFIG_DIR}/test.changes"
+}

--- a/tests/shunit2/tests.d/110_delete
+++ b/tests/shunit2/tests.d/110_delete
@@ -1,0 +1,34 @@
+test_delete_section()
+{
+	cp "${REF_DIR}/delete_section.data" "${CONFIG_DIR}/test"
+	${UCI} del test.section2
+	${UCI} commit
+	assertSameFile "${REF_DIR}/delete_section.result" "${CONFIG_DIR}/test"
+}
+
+test_delete_option()
+{
+	cp "${REF_DIR}/delete_option.data" "${CONFIG_DIR}/test"
+	${UCI} del test.section1.opt
+	${UCI} del test.section1.listopt
+	${UCI} commit
+	assertSameFile "${REF_DIR}/delete_option.result" "${CONFIG_DIR}/test"
+}
+
+test_delete_section_keep_comments()
+{
+	cp "${REF_DIR}/delete_section_keep_comments.data" "${CONFIG_DIR}/test"
+	${UCI} del test.section2
+	${UCI} commit
+	assertSameFile "${REF_DIR}/delete_section_keep_comments.result" "${CONFIG_DIR}/test"
+}
+
+test_delete_option_keep_comments()
+{
+	cp "${REF_DIR}/delete_option_keep_comments.data" "${CONFIG_DIR}/test"
+	${UCI} del test.section1.opt
+	${UCI} del test.section1.listopt
+	${UCI} commit
+	assertSameFile "${REF_DIR}/delete_option_keep_comments.result" "${CONFIG_DIR}/test"
+}
+

--- a/tests/shunit2/tests.sh
+++ b/tests/shunit2/tests.sh
@@ -24,6 +24,12 @@ rm -rf ${TESTS_DIR}
 mkdir -p ${TESTS_DIR}
 
 cat << 'EOF' > ${FULL_SUITE}
+oneTimeSetUp() {
+	if [ -n "${SHUNIT2_TEST_TO_RUN:-}" ]; then
+		echo "SHUNIT2_TEST_TO_RUN='$SHUNIT2_TEST_TO_RUN'"
+		suite_addTest "$SHUNIT2_TEST_TO_RUN"
+	fi
+}
 setUp() {
 	mkdir -p ${CONFIG_DIR} ${CHANGES_DIR} ${TMP_DIR}
 }
@@ -41,6 +47,7 @@ assertSameFile() {
 		echo "TEST:"
 		cat $test
 		echo "----"
+		diff -r $ref $test
 	}
 }
 assertNotSegFault()
@@ -60,6 +67,36 @@ assertFailWithNoReturn() {
 	assertNotIllegal $rv
 	assertNull "'$test' returns '$value'" "$value"
 }
+# assertFailWithNoReturn2 takes the command to execute as separate arguments
+# and preserves the arguments exactly, including whitespace
+assertFailWithNoReturn2() {
+	test=""; for arg in "$@"; do test="$test \"$arg\""; done
+	value="$("$@")"
+	rv=$?
+	assertFalse "$test does not fail" $rv
+	assertNotSegFault $rv
+	assertNotIllegal $rv
+	assertNull "$test returns '$value'" "$value"
+}
+# assertFailWithNoReturn2DiscardStderr takes the command to execute as separate arguments
+# and preserves the arguments exactly, including whitespace.
+# It redirects stderr to /dev/null, which is useful to get rid of noisy errors such
+# as long "Usage: ' messages.
+assertFailWithNoReturn2DiscardStderr() {
+	test=""; for arg in "$@"; do test="$test \"$arg\""; done
+	value="$("$@" 2>/dev/null)"
+	rv=$?
+	assertFalse "$test does not fail" $rv
+	assertNotSegFault $rv
+	assertNotIllegal $rv
+	assertNull "$test returns '$value'" "$value"
+}
+assertSuccess() {
+	test=""; for arg in "$@"; do test="$test \"$arg\""; done
+	"$@" 2>/dev/null
+	rv=$?
+	assertTrue "$test should have exit code 0 instead of $rv" $rv
+}
 EOF
 
 for suite in "${SCRIPTS_DIR}"/*
@@ -76,5 +113,8 @@ TMP_DIR="${TMP_DIR}" \
 UCI="${UCI}" \
 UCI_Q="${UCI_Q}" \
 /bin/sh ${FULL_SUITE}
+EXITSTATUS=$?
 
 rm -rf ${TESTS_DIR}
+
+exit ${EXITSTATUS}

--- a/uci.h
+++ b/uci.h
@@ -320,6 +320,14 @@ extern int uci_set_backend(struct uci_context *ctx, const char *name);
 extern bool uci_validate_text(const char *str);
 
 /**
+ * uci_validate_comment: validate a comment string for uci sections and uci options
+ * @str: comment
+ *
+ * this function checks if a given comment string is formatted correctly
+ */
+extern bool uci_validate_comment(const char *comment);
+
+/**
  * uci_parse_ptr: parse a uci string into a uci_ptr
  * @ctx: uci context
  * @ptr: target data structure
@@ -380,13 +388,24 @@ enum uci_flags {
 	UCI_FLAG_STRICT =        (1 << 0), /* strict mode for the parser */
 	UCI_FLAG_PERROR =        (1 << 1), /* print parser error messages */
 	UCI_FLAG_EXPORT_NAME =   (1 << 2), /* when exporting, name unnamed sections */
-	UCI_FLAG_SAVED_DELTA = (1 << 3), /* store the saved delta in memory as well */
+	UCI_FLAG_SAVED_DELTA =   (1 << 3), /* store the saved delta in memory as well */
+	UCI_FLAG_NO_COMMENTS =   (1 << 4), /* don't load, store, or save comments */
 };
 
 struct uci_element
 {
 	struct uci_list list;
 	enum uci_type type;
+	/*
+	 * comment format: [<comment_before>][<comment_after>]
+	 * <comment_before>: comment lines placed before the element line,
+	 *    concatenated, each starting with '#' and ending with '\n'.
+	 * <comment_after>: comment at the end of the element line itself,
+	 *    starting with '#' and ending without '\n'.
+	 * Example: "#commentlinebefore1\n#commentlinebefore2\n#commentafter"
+	 * NULL and empty string mean no comment.
+	 */
+	char *comment;
 	char *name;
 };
 
@@ -507,6 +526,16 @@ struct uci_ptr
 	struct uci_option *o;
 	struct uci_element *last;
 
+	/*
+	 * comment format: [<comment_before>][<comment_after>]
+	 * <comment_before>: comment lines placed before the element line,
+	 *    concatenated, each starting with '#' and ending with '\n'.
+	 * <comment_after>: comment at the end of the element line itself,
+	 *    starting with '#' and ending without '\n'.
+	 * Example: "#commentlinebefore1\n#commentlinebefore2\n#commentafter"
+	 * NULL and empty string mean no comment.
+	 */
+	const char *comment;
 	const char *package;
 	const char *section;
 	const char *option;

--- a/uci_internal.h
+++ b/uci_internal.h
@@ -27,6 +27,18 @@ struct uci_parse_context
 
 	/* private: */
 	struct uci_package *package;
+	/*
+	 * comment format: [<comment_before>][<comment_after>]
+	 * <comment_before>: comment lines placed before the element line,
+	 *    concatenated, each starting with '#' and ending with '\n'.
+	 * <comment_after>: comment at the end of the element line itself,
+	 *    starting with '#' and ending without '\n'.
+	 * Example: "#commentlinebefore1\n#commentlinebefore2\n#commentafter"
+	 * NULL and empty string mean no comment.
+	 */
+	char *commentbuf;
+	size_t commentbufsz;
+	size_t commentlen;
 	struct uci_section *section;
 	bool merge;
 	FILE *file;
@@ -42,19 +54,21 @@ struct uci_parse_context
 #define pctx_char(pctx, i)	((pctx)->buf[(i)])
 #define pctx_cur_char(pctx)	pctx_char(pctx, pctx_pos(pctx))
 
-#define uci_alloc_element(ctx, type, name, datasize) \
-	uci_to_ ## type (uci_alloc_generic(ctx, uci_type_ ## type, name, sizeof(struct uci_ ## type) + datasize))
+#define uci_alloc_element(ctx, comment, type, name, datasize) \
+	uci_to_ ## type (uci_alloc_generic(ctx, comment, uci_type_ ## type, name, sizeof(struct uci_ ## type) + datasize))
 
 extern const char *uci_confdir;
 extern const char *uci_savedir;
+
+__private int uci_add_section_with_comment(struct uci_context *ctx, struct uci_package *p, const char *comment, const char *type, struct uci_section **res);
 
 __private void *uci_malloc(struct uci_context *ctx, size_t size);
 __private void *uci_realloc(struct uci_context *ctx, void *ptr, size_t size);
 __private char *uci_strdup(struct uci_context *ctx, const char *str);
 __private bool uci_validate_str(const char *str, bool name, bool package);
-__private void uci_add_delta(struct uci_context *ctx, struct uci_list *list, int cmd, const char *section, const char *option, const char *value);
+__private void uci_add_delta(struct uci_context *ctx, struct uci_list *list, int cmd, const char *section, const char *option, const char *value, const char *comment);
 __private void uci_free_delta(struct uci_delta *h);
-__private struct uci_package *uci_alloc_package(struct uci_context *ctx, const char *name);
+__private struct uci_package *uci_alloc_package(struct uci_context *ctx, const char *comment, const char *name);
 
 __private FILE *uci_open_stream(struct uci_context *ctx, const char *filename, const char *origfilename, int pos, bool write, bool create);
 __private void uci_close_stream(FILE *stream);
@@ -66,7 +80,7 @@ __private void uci_alloc_parse_context(struct uci_context *ctx);
 __private void uci_cleanup(struct uci_context *ctx);
 __private struct uci_element *uci_lookup_list(struct uci_list *list, const char *name);
 __private void uci_free_package(struct uci_package **package);
-__private struct uci_element *uci_alloc_generic(struct uci_context *ctx, int type, const char *name, int size);
+__private struct uci_element *uci_alloc_generic(struct uci_context *ctx, const char *comment, int type, const char *name, int size);
 __private void uci_free_element(struct uci_element *e);
 __private struct uci_element *uci_expand_ptr(struct uci_context *ctx, struct uci_ptr *ptr, bool complete);
 

--- a/util.c
+++ b/util.c
@@ -101,6 +101,21 @@ bool uci_validate_text(const char *str)
 	return true;
 }
 
+bool uci_validate_comment(const char *comment)
+{
+	const char *readptr = comment;
+
+	do {
+		if (*readptr != '#')
+			return false;
+		readptr = strchr(readptr, '\n');
+		if (readptr)
+			readptr++;
+	} while (readptr && *readptr);
+
+	return true;
+}
+
 __private void uci_alloc_parse_context(struct uci_context *ctx)
 {
 	ctx->pctx = (struct uci_parse_context *) uci_malloc(ctx, sizeof(struct uci_parse_context));


### PR DESCRIPTION
This pull request implements preservation of comments in configuration files.

Comment lines before an entry, and the comment at the end of an entry are considered to be associated with that entry.
    
Example:
```
# this comment line is associated with section2

  # this comment line is associated with section2
config type section2 # this comment is associated with section 2
# this comment line is associated with opt
    
        # this comment line is associated with opt
        option opt 'val' # this comment is associated with opt
    
      # this comment line is not associated with any entry
```

Wih option `-D`, uci works as before and strips comments. The following commands have enhanced behaviour:
  * `uci import` preserves comments of unchanged configuration entries, and imports entries with their associated comments
  * `uci export` exports entries with their associated comments
  * `uci 'commit` preserves comments of unchanged configuration entries when committing changes with uci commands 'add', 'delete', 'set', 'add_list', and/or 'del_list'.
  * `uci get '<config>.<section>' '#'` shows the section comment
  * `uci get '<config>.<section>.<option> '#'` shows the option comment
  * `uci set '<config>.<section>=<value>' '<comment>'` sets the section value and comment
  * `uci set '<config>.<section>.option=<value>' '<comment>'` sets the option value and comment
  * `uci add_list '<config>.<section>.option=<value> '<comment>'` adds a list entry with value and comment
  * `uci changes` also shows comments
  * `uci show` does not show comments
  * `uci batch` supports the above commands

Features:
  * Comments are auto-indented if preserved, set or added.
  * The new delta file format is both backward compatible and forward compatible. Older uci versions interpret the addition in the new format as comment and ignores it.
  * Comments at the end of the file are not preserved because they do not belong to an entry.

I've added lots of shunit2 tests to verify the implementation.

An example of a result: the above example after and option 'opt2' has been added:
```

# this comment line is associated with section2
# this comment line is associated with section2
config type section2 # this comment is associated with section 2
        # this comment line is associated with opt
        # this comment line is associated with opt
        option opt 'val' # this comment is associated with opt
        # comment line for new option 'opt2'
        option opt2 'val2'

```
