### PR TITLE
tests: unhide shunit2 test failures

### DIFF
--- a/tests/shunit2/tests.sh
+++ b/tests/shunit2/tests.sh
@@ -76,5 +76,8 @@ TMP_DIR="${TMP_DIR}" \
 UCI="${UCI}" \
 UCI_Q="${UCI_Q}" \
 /bin/sh ${FULL_SUITE}
+EXITSTATUS=$?
 
 rm -rf ${TESTS_DIR}
+
+exit ${EXITSTATUS}


### PR DESCRIPTION
Fix for issue https://github.com/openwrt/uci/issues/21

shunit2 test with failing subtest incorrectly produced:
```
      Start 2: shunit2
  2/2 Test #2: shunit2 ..........................   Passed   52.70 sec

  100% tests passed, 0 tests failed out of 2
```
now correctly produces:
```
      Start 2: shunit2
  2/2 Test #2: shunit2 ..........................***Failed   53.68 sec
  #
  # Performing tests
  #
  ...
  test_get_option
  ASSERT:expected:<badval> but was:<val>
  test_get_option_multiline
  ...

  #
  # Test report
  #
  tests passed:   111  99%
  tests failed:     1   1%
  tests skipped:    0   0%
  tests total:    112 100%

  50% tests passed, 1 tests failed out of 2

  Total Test time (real) =  59.67 sec

  The following tests FAILED:
        2 - shunit2 (Failed)
  Errors while running CTest
  make: *** [Makefile:74: test] Error 8
  make: Leaving directory '/home/user/repos/uci/build'
```